### PR TITLE
Add select/number configuration entities for door unlock mode

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,6 @@
 MIT License
 
+Copyright (c) 2024 - 2025  Seb Ruiz @sebr
 Copyright (c) 2019 - 2024  Joakim Sørensen @ludeeus
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/README.md
+++ b/README.md
@@ -6,14 +6,44 @@ If this integration has been useful to you, please consider chipping in and buyi
 
 [!["Buy Me A Coffee"](https://www.buymeacoffee.com/assets/img/custom_images/orange_img.png)](https://www.buymeacoffee.com/sebr)
 
-**This integration will set up the following platforms.**
+**This integration will set up the following platforms:**
 
 Platform | Description
 -- | --
 `lock` | A lock for each configured Door.
+`number` | A number input which is used to define the duration of a timed unlock operation for each Door.
+`select` | A select which is used to choose the unlock operation of each door (i.e. Unlock or Timed Unlock).
 `alarm_control_panel` | For each Area that can be armed or disarmed.
-`binary_sensor` | For each Input and for metadata of each Door.
+`binary_sensor` | For each Input and for Door attributes such as Open or Isolated states.
 `switch` | A switch for each Siren or Strobe.
+
+## Supported Inception Entities
+
+### Doors
+
+For each door that the authenticated user has permission to access, the following entities are created:
+* A `lock` entity to lock and unlock the door. By default, the `lock.unlock` action will permanently unlock the door.
+* A `select` entity to choose the unlock operation of the door. The options are `Unlock` or `Timed Unlock`.
+* A `number` entity to set the duration of a timed unlock operation. The duration is in seconds and the default value is **5 seconds**.
+* `binary_sensor` entities which indicate: Open, Forced, Held Open to Long, Reader Tamper
+
+### Areas
+
+For each area that the authenticated user has permission to access, the following entities are created:
+* An `alarm_control_panel` entity to arm and disarm the area. If multi-mode area arming is enabled, Night and Perimiter modes are also available.
+
+### Inputs
+
+For each input that the authenticated user has permission to access, the following entities are created:
+* A `binary_sensor` entity to indicate the state of the input. Calculated inputs such as forced and held open are disabled by default. The device class is inferred from the input's name.
+* A `switch` entity to control if the input has been Isolated
+
+NB: only inputs which are non-logical are exposed.
+
+### Outputs
+
+For each output that the authenticated user has permission to access, the following entities are created:
+* A `switch` entity to control the output. Typically a siren or strobe.
 
 ## Installation
 

--- a/custom_components/inception/__init__.py
+++ b/custom_components/inception/__init__.py
@@ -23,6 +23,7 @@ PLATFORMS: list[Platform] = [
     Platform.ALARM_CONTROL_PANEL,
     Platform.BINARY_SENSOR,
     Platform.LOCK,
+    Platform.NUMBER,
     Platform.SELECT,
     Platform.SWITCH,
 ]

--- a/custom_components/inception/__init__.py
+++ b/custom_components/inception/__init__.py
@@ -11,8 +11,7 @@ from typing import TYPE_CHECKING
 
 from homeassistant.const import Platform
 
-from custom_components.inception.const import DOMAIN
-
+from .const import DOMAIN
 from .coordinator import InceptionUpdateCoordinator
 
 if TYPE_CHECKING:
@@ -24,6 +23,7 @@ PLATFORMS: list[Platform] = [
     Platform.ALARM_CONTROL_PANEL,
     Platform.BINARY_SENSOR,
     Platform.LOCK,
+    Platform.SELECT,
     Platform.SWITCH,
 ]
 

--- a/custom_components/inception/alarm_control_panel.py
+++ b/custom_components/inception/alarm_control_panel.py
@@ -45,6 +45,7 @@ async def async_setup_entry(
             coordinator=coordinator,
             entity_description=InceptionAlarmDescription(
                 key=area.entity_info.id,
+                name=area.entity_info.name,
             ),
             data=area,
         )

--- a/custom_components/inception/binary_sensor.py
+++ b/custom_components/inception/binary_sensor.py
@@ -12,7 +12,7 @@ from homeassistant.components.binary_sensor import (
 )
 from homeassistant.helpers.device_registry import DeviceInfo
 
-from .const import DOMAIN, LOGGER, MANUFACTURER
+from .const import DOMAIN, MANUFACTURER
 from .entity import InceptionEntity
 from .pyinception.schemas.door import DoorPublicState
 from .pyinception.schemas.input import (
@@ -189,10 +189,7 @@ class InceptionInputBinarySensor(
 ):
     """inception binary_sensor for Inputs."""
 
-    entity_description: InceptionBinarySensorDescription
     data: InputSummaryEntry
-
-    _attr_has_entity_name = True
 
     def __init__(
         self,
@@ -213,23 +210,13 @@ class InceptionInputBinarySensor(
             manufacturer=MANUFACTURER,
         )
 
-        LOGGER.debug(
-            "Input Binary Sensor: %s %s %s",
-            data.entity_info.name,
-            data.entity_info.input_type,
-            data.public_state,
-        )
-
 
 class InceptionDoorBinarySensor(
     InceptionBinarySensor,
 ):
     """inception binary_sensor for Doors."""
 
-    entity_description: InceptionBinarySensorDescription
     data: DoorSummaryEntry
-
-    _attr_has_entity_name = True
 
     def __init__(
         self,
@@ -245,4 +232,5 @@ class InceptionDoorBinarySensor(
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, self._device_id)},
             name=data.entity_info.name,
+            manufacturer=MANUFACTURER,
         )

--- a/custom_components/inception/coordinator.py
+++ b/custom_components/inception/coordinator.py
@@ -9,9 +9,8 @@ from homeassistant.core import callback
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from custom_components.inception.pyinception.api import InceptionApiClient
-
 from .const import DOMAIN, LOGGER
+from .pyinception.api import InceptionApiClient
 from .pyinception.data import InceptionApiData
 
 if TYPE_CHECKING:

--- a/custom_components/inception/entity.py
+++ b/custom_components/inception/entity.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 from homeassistant.core import callback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
+from .const import LOGGER
 from .coordinator import InceptionUpdateCoordinator
 
 if TYPE_CHECKING:
@@ -35,6 +36,13 @@ class InceptionEntity(CoordinatorEntity[InceptionUpdateCoordinator]):
         self._inception_object = inception_object
         self._attr_extra_state_attributes = inception_object.extra_fields
         self._update_attrs()
+
+        LOGGER.info(
+            "Creating %s: %s - %s",
+            self.__class__.__name__,
+            inception_object.entity_info.name,
+            entity_description.name,
+        )
 
     @property
     def name(self) -> str:

--- a/custom_components/inception/entity.py
+++ b/custom_components/inception/entity.py
@@ -37,7 +37,7 @@ class InceptionEntity(CoordinatorEntity[InceptionUpdateCoordinator]):
         self._attr_extra_state_attributes = inception_object.extra_fields
         self._update_attrs()
 
-        LOGGER.info(
+        LOGGER.debug(
             "Creating %s: %s - %s",
             self.__class__.__name__,
             inception_object.entity_info.name,

--- a/custom_components/inception/lock.py
+++ b/custom_components/inception/lock.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import re
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
@@ -11,7 +12,9 @@ from homeassistant.components.lock import (
     LockEntity,
     LockEntityDescription,
 )
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import entity_platform
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.device_registry import DeviceInfo
 
 from .const import DOMAIN, MANUFACTURER
@@ -20,6 +23,7 @@ from .pyinception.schemas.door import (
     DoorControlType,
     DoorPublicState,
 )
+from .select import GRANT_ACCESS
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
@@ -28,6 +32,9 @@ if TYPE_CHECKING:
     from .coordinator import InceptionUpdateCoordinator
     from .data import InceptionConfigEntry
     from .pyinception.schemas.door import DoorSummaryEntry
+
+_LOGGER = logging.getLogger(__name__)
+
 
 SERVICE_UNLOCK = "unlock"
 
@@ -78,6 +85,8 @@ class InceptionLock(InceptionEntity, LockEntity):
     data: DoorSummaryEntry
 
     _attr_has_entity_name = True
+    _device_id: str
+    _unlock_strategy_entity_id: str | None = None
 
     def __init__(
         self,
@@ -101,6 +110,38 @@ class InceptionLock(InceptionEntity, LockEntity):
             ).strip(),
             manufacturer=MANUFACTURER,
         )
+
+    async def _get_unlock_entity(self) -> str | None:
+        if self._unlock_strategy_entity_id is None:
+            device_registry = dr.async_get(self.hass)
+            device = device_registry.async_get_device(
+                {(DOMAIN, self._device_id)}
+            )  # Use the same identifier
+
+            if device:
+                entity_registry = er.async_get(self.hass)
+
+                # Correct way to get entities for a device:
+                select_entity_ids = [
+                    entry.entity_id
+                    for entry in er.async_entries_for_device(entity_registry, device.id)
+                    if entry.domain == "select"
+                ]
+
+                if len(select_entity_ids) == 1:
+                    self._unlock_strategy_entity_id = select_entity_ids[0]
+
+                    _LOGGER.debug("Select entity found for device %s", device.id)
+                elif len(select_entity_ids) > 1:
+                    _LOGGER.error(
+                        "More than one select entity found for device %s", device.id
+                    )
+                else:
+                    _LOGGER.error("Select entity not found for device %s", device.id)
+            else:
+                _LOGGER.error("Select not found for lock %s", self.name)
+
+        return self._unlock_strategy_entity_id
 
     @property
     def name(self) -> str:
@@ -133,16 +174,18 @@ class InceptionLock(InceptionEntity, LockEntity):
 
     async def async_unlock(self) -> None:
         """Unlock the device."""
-        return await self._door_control(
-            data={
-                "Type": "ControlDoor",
-                "DoorControlType": DoorControlType.UNLOCK,  # Unlock is a permanent open
-            },
-        )
+        unlock_strategy_entity_id = await self._get_unlock_entity()
+        if unlock_strategy_entity_id is not None:
+            unlock_strategy = self.hass.states.get(unlock_strategy_entity_id)
+            if unlock_strategy is not None and unlock_strategy.state == GRANT_ACCESS:
+                return await self.unlock_service(time_secs=5)
 
-    async def unlock_service(self, time_secs: int | None) -> None:
+        return await self.unlock_service()
+
+    async def unlock_service(self, time_secs: int | None = None) -> None:
         """Unlock the device. If a time is provided, the device will issue a timed unlock."""  # noqa: E501
         if time_secs is None:
+            _LOGGER.info("Unlocking door")
             return await self._door_control(
                 data={
                     "Type": "ControlDoor",
@@ -150,6 +193,7 @@ class InceptionLock(InceptionEntity, LockEntity):
                 },
             )
 
+        _LOGGER.info("Granting access for %s seconds", time_secs)
         return await self._door_control(
             data={
                 "Type": "ControlDoor",

--- a/custom_components/inception/lock.py
+++ b/custom_components/inception/lock.py
@@ -86,6 +86,8 @@ class InceptionLock(InceptionEntity, LockEntity):
 
     _attr_has_entity_name = True
     _device_id: str
+
+    _has_loaded_unlock_strategy_entity_id: bool = False
     _unlock_strategy_entity_id: str | None = None
 
     def __init__(
@@ -111,8 +113,9 @@ class InceptionLock(InceptionEntity, LockEntity):
             manufacturer=MANUFACTURER,
         )
 
-    async def _get_unlock_entity(self) -> str | None:
-        if self._unlock_strategy_entity_id is None:
+    async def _get_unlock_select_entity(self) -> str | None:
+        if self._has_loaded_unlock_strategy_entity_id is False:
+            self._has_loaded_unlock_strategy_entity_id = True
             device_registry = dr.async_get(self.hass)
             device = device_registry.async_get_device(
                 {(DOMAIN, self._device_id)}
@@ -174,7 +177,7 @@ class InceptionLock(InceptionEntity, LockEntity):
 
     async def async_unlock(self) -> None:
         """Unlock the device."""
-        unlock_strategy_entity_id = await self._get_unlock_entity()
+        unlock_strategy_entity_id = await self._get_unlock_select_entity()
         if unlock_strategy_entity_id is not None:
             unlock_strategy = self.hass.states.get(unlock_strategy_entity_id)
             if unlock_strategy is not None and unlock_strategy.state == GRANT_ACCESS:

--- a/custom_components/inception/number.py
+++ b/custom_components/inception/number.py
@@ -1,0 +1,143 @@
+"""Binary sensor platform for inception."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from homeassistant.components.number import (
+    NumberDeviceClass,
+    NumberEntity,
+    NumberEntityDescription,
+    NumberMode,
+    RestoreNumber,
+)
+from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN, EntityCategory
+from homeassistant.helpers.device_registry import DeviceInfo
+
+from .const import DOMAIN, MANUFACTURER
+from .entity import InceptionEntity
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+    from .coordinator import InceptionUpdateCoordinator
+    from .data import InceptionConfigEntry
+    from .pyinception.schemas.door import (
+        DoorSummaryEntry,
+    )
+    from .pyinception.schemas.entities import (
+        InceptionSummaryEntry,
+    )
+
+_LOGGER = logging.getLogger(__name__)
+DEFAULT_TIMED_UNLOCK_DURATION = 5
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: InceptionConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the number platform."""
+    coordinator: InceptionUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+
+    entities = [
+        InceptionTimedUnlockNumber(
+            coordinator=coordinator,
+            entity_description=InceptionNumberDescription(
+                key=f"{door.entity_info.id}_timed_unlock_time",
+                name="Timed Unlock Duration",
+                entity_category=EntityCategory.CONFIG,
+                translation_key="timed_unlock_duration",
+                device_class=NumberDeviceClass.DURATION,
+                native_unit_of_measurement="s",
+                native_step=1,
+                mode=NumberMode.BOX,
+            ),
+            data=door,
+        )
+        for door in coordinator.data.doors.get_items()
+    ]
+
+    async_add_entities(entities)
+
+
+@dataclass(frozen=True, kw_only=True)
+class InceptionNumberDescription(NumberEntityDescription):
+    """Describes Inception number entity."""
+
+
+class InceptionNumber(InceptionEntity, NumberEntity):
+    """inception number class."""
+
+    data: InceptionSummaryEntry
+
+    def __init__(
+        self,
+        coordinator: InceptionUpdateCoordinator,
+        entity_description: NumberEntityDescription,
+        data: InceptionSummaryEntry,
+    ) -> None:
+        """Initialize the number class."""
+        super().__init__(
+            coordinator, entity_description=entity_description, inception_object=data
+        )
+        self.data = data
+        self.unique_id = entity_description.key
+        self._device_id = data.entity_info.id
+
+
+class InceptionTimedUnlockNumber(
+    InceptionNumber,
+    RestoreNumber,
+):
+    """inception select for Doors."""
+
+    _attr_has_entity_name = True
+    _attr_should_poll = False
+    entity_description: InceptionNumberDescription
+
+    def __init__(
+        self,
+        coordinator: InceptionUpdateCoordinator,
+        entity_description: InceptionNumberDescription,
+        data: DoorSummaryEntry,
+    ) -> None:
+        """Initialize the number class."""
+        super().__init__(coordinator, entity_description=entity_description, data=data)
+
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, data.entity_info.id)},
+            manufacturer=MANUFACTURER,
+        )
+        self.entity_description = entity_description
+        self._attr_current_option = None
+        self._attr_native_min_value = 1
+        self._attr_extra_state_attributes = {
+            "type": "timed_unlock_duration",
+        }
+
+    @property
+    def name(self) -> str:
+        """Return the name of the entity."""
+        return "Timed Unlock Duration"
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Update the current value."""
+        self._attr_native_value = value
+        self.async_write_ha_state()
+
+    async def async_added_to_hass(self) -> None:
+        """Restore last state."""
+        await super().async_added_to_hass()
+        if (
+            (last_state := await self.async_get_last_state())
+            and (last_number_data := await self.async_get_last_number_data())
+            and last_state.state not in (STATE_UNKNOWN, STATE_UNAVAILABLE)
+        ):
+            self._attr_native_value = last_number_data.native_value
+        else:
+            self._attr_native_value = DEFAULT_TIMED_UNLOCK_DURATION

--- a/custom_components/inception/select.py
+++ b/custom_components/inception/select.py
@@ -27,11 +27,8 @@ if TYPE_CHECKING:
         InceptionSummaryEntry,
     )
 
-# Define possible unlock strategies and their descriptions
-GRANT_ACCESS = "grant_access"
+TIMED_UNLOCK = "timed_unlock"
 UNLOCK = "unlock"
-
-
 DEFAULT_UNLOCK_STRATEGY = UNLOCK
 
 _LOGGER = logging.getLogger(__name__)
@@ -51,7 +48,7 @@ async def async_setup_entry(
             entity_description=InceptionSelectDescription(
                 key=f"{door.entity_info.id}_unlock_mechanism",
                 name="Unlock Strategy",
-                options=[UNLOCK, GRANT_ACCESS],
+                options=[UNLOCK, TIMED_UNLOCK],
                 entity_category=EntityCategory.CONFIG,
                 translation_key="unlock_strategy",
             ),
@@ -94,9 +91,10 @@ class InceptionUnlockStrategySelect(
     InceptionSelect,
     RestoreEntity,
 ):
-    """inception select for Doors."""
+    """inception unlock strategy select for Doors."""
 
     _attr_has_entity_name = True
+    _attr_should_poll = False
     entity_description: InceptionSelectDescription
 
     def __init__(

--- a/custom_components/inception/select.py
+++ b/custom_components/inception/select.py
@@ -1,0 +1,165 @@
+"""Binary sensor platform for inception."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from homeassistant.components.select import SelectEntity, SelectEntityDescription
+from homeassistant.const import EntityCategory
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.restore_state import RestoreEntity
+
+from .const import DOMAIN, MANUFACTURER
+from .entity import InceptionEntity
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+    from .coordinator import InceptionUpdateCoordinator
+    from .data import InceptionConfigEntry
+    from .pyinception.schemas.door import (
+        DoorSummaryEntry,
+    )
+    from .pyinception.schemas.entities import (
+        InceptionSummaryEntry,
+    )
+
+# Define possible unlock strategies and their descriptions
+UNLOCK_STRATEGIES = {
+    "permanent": "Unlock permanently",
+    "timed": "Unlock for a fixed duration",
+}
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: InceptionConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the binary_sensor platform."""
+    coordinator: InceptionUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+
+    entities = [
+        InceptionUnlockStrategySelect(
+            coordinator=coordinator,
+            entity_description=InceptionBinarySensorDescription(
+                key=f"{door.entity_info.id}_unlock_mechanism",
+                name="Unlock Mechanism",
+                options=list(UNLOCK_STRATEGIES.values()),
+                entity_category=EntityCategory.CONFIG,
+            ),
+            data=door,
+        )
+        for door in coordinator.data.doors.get_items()
+    ]
+
+    async_add_entities(entities)
+
+
+@dataclass(frozen=True, kw_only=True)
+class InceptionBinarySensorDescription(SelectEntityDescription):
+    """Describes Inception select entity."""
+
+    options: list[str] = field(default_factory=list)
+
+
+class InceptionSelect(InceptionEntity, SelectEntity):
+    """inception binary_sensor class."""
+
+    data: InceptionSummaryEntry
+
+    def __init__(
+        self,
+        coordinator: InceptionUpdateCoordinator,
+        entity_description: SelectEntityDescription,
+        data: InceptionSummaryEntry,
+    ) -> None:
+        """Initialize the binary_sensor class."""
+        super().__init__(
+            coordinator, entity_description=entity_description, inception_object=data
+        )
+        self.data = data
+        self.unique_id = entity_description.key
+
+
+class InceptionUnlockStrategySelect(
+    InceptionSelect,
+    RestoreEntity,
+):
+    """inception select for Doors."""
+
+    _attr_has_entity_name = True
+    entity_description: InceptionBinarySensorDescription
+
+    def __init__(
+        self,
+        coordinator: InceptionUpdateCoordinator,
+        entity_description: InceptionBinarySensorDescription,
+        data: DoorSummaryEntry,
+    ) -> None:
+        """Initialize the binary_sensor class."""
+        super().__init__(coordinator, entity_description=entity_description, data=data)
+
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, data.entity_info.id)},
+            manufacturer=MANUFACTURER,
+        )
+        self._attr_current_option = None
+        self.entity_description = entity_description
+
+    @property
+    def name(self) -> str:
+        """Return the name of the entity."""
+        return "Unlock Strategy"
+
+    async def async_added_to_hass(self) -> None:
+        """Restore state."""
+        await super().async_added_to_hass()
+        last_state = await self.async_get_last_state()
+        if last_state:
+            try:
+                self._attr_current_option = last_state.state
+                if self._attr_current_option not in self._attr_options:
+                    _LOGGER.warning(
+                        "Restored unlock strategy '%s' is invalid. Using default.",
+                        self._attr_current_option,
+                    )
+                    self._attr_current_option = self.entity_description.options[0]
+            except ValueError:
+                _LOGGER.warning(
+                    "Could not restore unlock strategy. Falling back to default."
+                )
+                self._attr_current_option = self.entity_description.options[0]
+        else:
+            self._attr_current_option = self.entity_description.options[
+                0
+            ]  # Set initial value if no history
+
+    async def async_select_option(self, option: str) -> None:
+        """Handle selection of an unlock strategy."""
+        if option not in self.entity_description.options:
+            msg = f"Invalid unlock strategy: {option}"
+            raise ValueError(msg)
+
+        self._attr_current_option = option
+        self.async_write_ha_state()
+
+        # Now you can use the selected strategy in your lock platform:
+        _LOGGER.info("Unlock strategy set to: %s", self._attr_current_option)
+
+        # To get the KEY, which is important for your logic:
+        selected_key = list(UNLOCK_STRATEGIES.keys())[
+            list(UNLOCK_STRATEGIES.values()).index(option)
+        ]
+        _LOGGER.info("Unlock strategy key: %s", selected_key)
+
+        # Example usage:
+        # if selected_key == "permanent":
+        #     self.lock.unlock_permanently()
+        # elif selected_key == "timed":
+        #     self.lock.unlock_for_seconds(30)

--- a/custom_components/inception/select.py
+++ b/custom_components/inception/select.py
@@ -32,7 +32,7 @@ GRANT_ACCESS = "grant_access"
 UNLOCK = "unlock"
 
 
-_DEFAULT_UNLOCK_STRATEGY = UNLOCK
+DEFAULT_UNLOCK_STRATEGY = UNLOCK
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -114,6 +114,9 @@ class InceptionUnlockStrategySelect(
         )
         self._attr_current_option = None
         self.entity_description = entity_description
+        self._attr_extra_state_attributes = {
+            "type": "unlock_strategy",
+        }
 
     @property
     def name(self) -> str:
@@ -132,15 +135,15 @@ class InceptionUnlockStrategySelect(
                         "Restored unlock strategy '%s' is invalid. Using default.",
                         self._attr_current_option,
                     )
-                    self._attr_current_option = _DEFAULT_UNLOCK_STRATEGY
+                    self._attr_current_option = DEFAULT_UNLOCK_STRATEGY
             except ValueError:
                 _LOGGER.warning(
                     "Could not restore unlock strategy. Falling back to default."
                 )
-                self._attr_current_option = _DEFAULT_UNLOCK_STRATEGY
+                self._attr_current_option = DEFAULT_UNLOCK_STRATEGY
         else:
             self._attr_current_option = (
-                _DEFAULT_UNLOCK_STRATEGY  # Set initial value if no history
+                DEFAULT_UNLOCK_STRATEGY  # Set initial value if no history
             )
 
     async def async_select_option(self, option: str) -> None:
@@ -155,4 +158,4 @@ class InceptionUnlockStrategySelect(
         self.async_write_ha_state()
 
         # Now you can use the selected strategy in your lock platform:
-        _LOGGER.info("Unlock strategy set to: %s", self._attr_current_option)
+        _LOGGER.debug("Unlock strategy set to: %s", self._attr_current_option)

--- a/custom_components/inception/services.yaml
+++ b/custom_components/inception/services.yaml
@@ -1,13 +1,12 @@
-timed_unlock:
+unlock:
   target:
       entity:
         domain: lock
   fields:
     time_secs:
-      required: true
+      required: false
       selector:
         number:
           min: 0
           max: 7200
           unit_of_measurement: seconds
-

--- a/custom_components/inception/switch.py
+++ b/custom_components/inception/switch.py
@@ -12,7 +12,7 @@ from homeassistant.components.switch import (
 )
 from homeassistant.helpers.device_registry import DeviceInfo
 
-from .const import DOMAIN, LOGGER
+from .const import DOMAIN
 from .entity import InceptionEntity
 from .pyinception.schemas.input import (
     InputPublicState,
@@ -131,7 +131,6 @@ class InceptionInputSwitch(InceptionSwitch, SwitchEntity):
     ) -> None:
         """Initialize the switch class."""
         super().__init__(coordinator, entity_description=entity_description, data=data)
-        LOGGER.debug("Creating input switch %s", data.entity_info.name)
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, data.entity_info.id)},
             name=data.entity_info.name,

--- a/custom_components/inception/translations/en.json
+++ b/custom_components/inception/translations/en.json
@@ -34,7 +34,7 @@
                 "name": "Unlock Strategy",
                 "state": {
                     "unlock": "Unlock",
-                    "grant_access": "Grant Access"
+                    "timed_unlock": "Timed Unlock"
                 }
             }
         }

--- a/custom_components/inception/translations/en.json
+++ b/custom_components/inception/translations/en.json
@@ -17,13 +17,13 @@
         }
     },
     "services": {
-        "timed_unlock": {
-            "name": "Timed unlock",
-            "description": "Unlocks a door for a specified number of seconds.",
+        "unlock": {
+            "name": "Unlock",
+            "description": "Unlocks a door. If a time is provided, a timed unlock is used.",
             "fields": {
                 "time_secs": {
                     "name": "Seconds",
-                    "description": "Number of seconds to unlock the door."
+                    "description": "Number of seconds to grant access."
                 }
             }
         }

--- a/custom_components/inception/translations/en.json
+++ b/custom_components/inception/translations/en.json
@@ -27,5 +27,16 @@
                 }
             }
         }
+    },
+    "entity": {
+        "select": {
+            "unlock_strategy": {
+                "name": "Unlock Strategy",
+                "state": {
+                    "unlock": "Unlock",
+                    "grant_access": "Grant Access"
+                }
+            }
+        }
     }
 }

--- a/scripts/develop
+++ b/scripts/develop
@@ -11,7 +11,7 @@ if [[ ! -d "${PWD}/config" ]]; then
 fi
 
 # Set the path to custom_components
-## This let's us have the structure we want <root>/custom_components/integration_blueprint
+## This let's us have the structure we want <root>/custom_components/inception
 ## while at the same time have Home Assistant configuration inside <root>/config
 ## without resulting to symlinks.
 export PYTHONPATH="${PYTHONPATH}:${PWD}/custom_components"


### PR DESCRIPTION
Allows Home Assistant to use either `Unlock` or `Timed Unlock` when calling `lock.unlock`