### PR TITLE
Set `Isolate` switches to hidden by default

### DIFF
--- a/custom_components/inception/switch.py
+++ b/custom_components/inception/switch.py
@@ -77,6 +77,7 @@ async def async_setup_entry(
                 device_class=SwitchDeviceClass.SWITCH,
                 name="Isolated",
                 has_entity_name=True,
+                entity_registry_visible_default=False,
                 value_fn=lambda data: data.public_state is not None
                 and bool(data.public_state & InputPublicState.ISOLATED),
             ),


### PR DESCRIPTION
This prevents the switches from being automatically added to auto-populated dashboards