### PR TITLE
Add diagnostic sensor for last review event

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ Platform | Description
 `select` | A select which is used to choose the unlock operation of each door (i.e. Unlock or Timed Unlock).
 `alarm_control_panel` | For each Area that can be armed or disarmed.
 `binary_sensor` | For each Input and for Door attributes such as Open or Isolated states.
-`switch` | A switch for each Siren or Strobe.
+`sensor` | Diagnostic sensor for the last received review event.
+`switch` | A switch for each Siren or Strobe, plus switches to control review event monitoring.
 
 ## Supported Inception Entities
 
@@ -46,6 +47,19 @@ For each input that the authenticated user has permission to access, the followi
 For each output that the authenticated user has permission to access, the following entities are created:
 
 * A `switch` entity to control the output. Typically a siren or strobe.
+
+### Diagnostic Sensors
+
+The integration provides diagnostic sensors for monitoring and troubleshooting:
+
+* **Last Review Event Sensor**: A diagnostic sensor that displays the message description of the most recently received review event. All event data is available as entity attributes including event ID, timestamps, who/what/where information, and message details. This sensor is automatically disabled when review event monitoring is turned off and is useful for debugging event reception and creating dashboards showing recent security activity.
+
+### Review Event Controls
+
+The integration includes configuration switches to control review event monitoring:
+
+* **Global Review Events Switch**: Master switch to enable/disable all review event monitoring
+* **Category Switches**: Individual switches for each event category (System, Audit, Access, Security, Hardware) allowing fine-grained control over which types of events are monitored
 
 ## Events
 

--- a/custom_components/inception/__init__.py
+++ b/custom_components/inception/__init__.py
@@ -25,6 +25,7 @@ PLATFORMS: list[Platform] = [
     Platform.LOCK,
     Platform.NUMBER,
     Platform.SELECT,
+    Platform.SENSOR,
     Platform.SWITCH,
 ]
 

--- a/custom_components/inception/sensor.py
+++ b/custom_components/inception/sensor.py
@@ -1,0 +1,215 @@
+"""Sensor platform for inception."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, cast
+
+from homeassistant.components.sensor import (
+    SensorEntity,
+    SensorEntityDescription,
+)
+from homeassistant.const import EntityCategory
+from homeassistant.core import callback
+from homeassistant.helpers.entity_registry import RegistryEntryDisabler
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN, EVENT_REVIEW_EVENT
+from .coordinator import InceptionUpdateCoordinator
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from homeassistant.core import HomeAssistant
+
+    from .data import InceptionConfigEntry
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: InceptionConfigEntry,
+    async_add_entities: Any,
+) -> None:
+    """Set up the sensor platform."""
+    coordinator = hass.data[DOMAIN][entry.entry_id]
+
+    entities = [
+        InceptionLastReviewEventSensor(
+            coordinator=coordinator,
+            entity_description=SensorEntityDescription(
+                key="last_review_event",
+                name="Last Review Event",
+                entity_category=EntityCategory.DIAGNOSTIC,
+                icon="mdi:math-log",
+            ),
+        )
+    ]
+
+    async_add_entities(entities)
+
+
+class InceptionLastReviewEventSensor(
+    CoordinatorEntity[InceptionUpdateCoordinator], SensorEntity
+):
+    """Sensor that shows the last review event message description."""
+
+    def __init__(
+        self,
+        coordinator: InceptionUpdateCoordinator,
+        entity_description: SensorEntityDescription,
+    ) -> None:
+        """Initialize the sensor."""
+        super().__init__(coordinator=coordinator)
+        self.entity_description = entity_description
+        self._attr_has_entity_name = True
+        self._attr_unique_id = (
+            f"{coordinator.config_entry.entry_id}_{entity_description.key}"
+        )
+        self._last_event_data: dict[str, Any] | None = None
+        self._event_listener_remove: Callable[[], None] | None = None
+
+    async def async_added_to_hass(self) -> None:
+        """Run when entity is added to Home Assistant."""
+        await super().async_added_to_hass()
+
+        # Start event listener
+        self._start_event_listener()
+
+        # Update enabled state based on current switch state
+        await self._update_entity_enabled_state()
+
+        # Listen for entity registry updates to handle manual enable/disable
+        self.async_on_remove(
+            self.hass.bus.async_listen(
+                "entity_registry_updated",
+                self._handle_entity_registry_update,
+            )
+        )
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Run when entity will be removed from Home Assistant."""
+        # Clean up event listener
+        self._stop_event_listener()
+
+        await super().async_will_remove_from_hass()
+
+    async def _update_entity_enabled_state(self) -> None:
+        """Update the entity's enabled state based on review events switch."""
+        from homeassistant.helpers.entity_registry import async_get
+
+        coordinator = cast("InceptionUpdateCoordinator", self.coordinator)
+        entity_registry = async_get(self.hass)
+
+        if entity_entry := entity_registry.async_get(self.entity_id):
+            should_be_enabled = coordinator.review_events_global_enabled
+            if entity_entry.disabled_by is None and not should_be_enabled:
+                # Stop the event listener before disabling
+                self._stop_event_listener()
+                # Disable the entity
+                entity_registry.async_update_entity(
+                    self.entity_id, disabled_by=RegistryEntryDisabler.INTEGRATION
+                )
+            elif (
+                entity_entry.disabled_by == RegistryEntryDisabler.INTEGRATION
+                and should_be_enabled
+            ):
+                # Enable the entity
+                entity_registry.async_update_entity(self.entity_id, disabled_by=None)
+                # Start the event listener after enabling
+                self._start_event_listener()
+
+    def _start_event_listener(self) -> None:
+        """Start the event listener if not already running and entity is enabled."""
+        if (
+            self._event_listener_remove is None
+            and self.hass is not None
+            and self._is_entity_enabled()
+        ):
+            self._event_listener_remove = self.hass.bus.async_listen(
+                EVENT_REVIEW_EVENT,
+                self._handle_review_event,
+            )
+
+    def _stop_event_listener(self) -> None:
+        """Stop the event listener if running."""
+        if self._event_listener_remove is not None:
+            self._event_listener_remove()
+            self._event_listener_remove = None
+
+    def _is_entity_enabled(self) -> bool:
+        """Check if the entity is currently enabled."""
+        from homeassistant.helpers.entity_registry import async_get
+
+        if self.entity_id is None or self.hass is None:
+            return False
+
+        entity_registry = async_get(self.hass)
+        if entity_entry := entity_registry.async_get(self.entity_id):
+            return entity_entry.disabled_by is None
+        return True  # If not in registry yet, assume enabled
+
+    @callback
+    def _handle_entity_registry_update(self, event: Any) -> None:
+        """Handle entity registry updates to manage event listener state."""
+        # Check if this update is for our entity and disabled_by changed
+        if (
+            event.data.get("action") == "update"
+            and event.data.get("entity_id") == self.entity_id
+            and "disabled_by" in event.data.get("changes", {})
+        ):
+            if self._is_entity_enabled():
+                # Entity was enabled, start listener
+                self._start_event_listener()
+            else:
+                # Entity was disabled, stop listener
+                self._stop_event_listener()
+
+    @callback
+    def _handle_review_event(self, event: Any) -> None:
+        """Handle incoming review events."""
+        self._last_event_data = event.data
+        self.async_write_ha_state()
+
+    @property
+    def native_value(self) -> str | None:
+        """Return the state of the sensor."""
+        if self._last_event_data is None:
+            return None
+        return self._last_event_data.get("message_description", "Unknown")
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any] | None:
+        """Return the state attributes."""
+        if self._last_event_data is None:
+            return None
+
+        return {
+            "event_id": self._last_event_data.get("event_id"),
+            "description": self._last_event_data.get("description"),
+            "message_value": self._last_event_data.get("message_value"),
+            "message_category": self._last_event_data.get("message_category"),
+            "when": self._last_event_data.get("when"),
+            "reference_time": self._last_event_data.get("reference_time"),
+            "who": self._last_event_data.get("who"),
+            "who_id": self._last_event_data.get("who_id"),
+            "what": self._last_event_data.get("what"),
+            "what_id": self._last_event_data.get("what_id"),
+            "where": self._last_event_data.get("where"),
+            "where_id": self._last_event_data.get("where_id"),
+        }
+
+    @property
+    def entity_registry_enabled_default(self) -> bool:
+        """Return if entity should be enabled when first added to registry."""
+        coordinator = cast("InceptionUpdateCoordinator", self.coordinator)
+        return coordinator.review_events_global_enabled
+
+    @property
+    def device_info(self) -> dict[str, Any]:
+        """Return device information about this entity."""
+        coordinator = cast("InceptionUpdateCoordinator", self.coordinator)
+        return {
+            "identifiers": {(DOMAIN, coordinator.config_entry.entry_id)},
+            "name": "Inception Security System",
+            "manufacturer": "InnerRange",
+            "model": "Inception",
+        }

--- a/custom_components/inception/switch.py
+++ b/custom_components/inception/switch.py
@@ -264,7 +264,7 @@ class ReviewEventGlobalSwitch(SwitchEntity):
         self._attr_is_on = stored_data.get("global_enabled", False)
 
         # Store the global state in the coordinator for other switches to access
-        self.coordinator._review_events_global_enabled = self._attr_is_on
+        self.coordinator.review_events_global_enabled = self._attr_is_on or False
 
         # Schedule a deferred startup check to allow all entities to load first
         if self._attr_is_on:
@@ -308,7 +308,7 @@ class ReviewEventGlobalSwitch(SwitchEntity):
     async def _update_category_switches_availability(self) -> None:
         """Update the availability of all category switches."""
         # Store the global state in the coordinator for other switches to access
-        self.coordinator._review_events_global_enabled = self._attr_is_on
+        self.coordinator.review_events_global_enabled = self._attr_is_on or False
 
         # Force update of all entities by asking Home Assistant to refresh them
         entity_registry = async_get(self.hass)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -19,6 +19,7 @@ class TestInceptionIntegration:
             Platform.LOCK,
             Platform.NUMBER,
             Platform.SELECT,
+            Platform.SENSOR,
             Platform.SWITCH,
         ]
 

--- a/tests/unit/test_sensor.py
+++ b/tests/unit/test_sensor.py
@@ -1,0 +1,141 @@
+"""Test the sensor platform."""
+
+from unittest.mock import Mock
+
+import pytest
+from homeassistant.components.sensor import SensorEntityDescription
+from homeassistant.const import EntityCategory
+
+from custom_components.inception.coordinator import InceptionUpdateCoordinator
+from custom_components.inception.sensor import InceptionLastReviewEventSensor
+
+
+class TestInceptionLastReviewEventSensor:
+    """Test the InceptionLastReviewEventSensor."""
+
+    @pytest.fixture
+    def mock_coordinator(self) -> Mock:
+        """Create a mock coordinator."""
+        coordinator = Mock(spec=InceptionUpdateCoordinator)
+        coordinator.review_events_global_enabled = False
+
+        # Mock config_entry
+        coordinator.config_entry = Mock()
+        coordinator.config_entry.entry_id = "test_entry_id"
+
+        # Mock hass
+        coordinator.hass = Mock()
+        coordinator.hass.bus = Mock()
+        coordinator.hass.bus.async_listen = Mock()
+
+        return coordinator
+
+    @pytest.fixture
+    def sensor(self, mock_coordinator: Mock) -> InceptionLastReviewEventSensor:
+        """Create a sensor instance."""
+        entity_description = SensorEntityDescription(
+            key="last_review_event",
+            name="Last Review Event",
+            entity_category=EntityCategory.DIAGNOSTIC,
+            icon="mdi:security",
+        )
+        sensor = InceptionLastReviewEventSensor(
+            coordinator=mock_coordinator,
+            entity_description=entity_description,
+        )
+        # Mock the async_on_remove method and async_write_ha_state
+        sensor.async_on_remove = Mock()
+        sensor.async_write_ha_state = Mock()
+        return sensor
+
+    def test_initial_state(self, sensor: InceptionLastReviewEventSensor) -> None:
+        """Test the sensor starts with no value."""
+        assert sensor.native_value is None
+        assert sensor.extra_state_attributes is None
+
+    def test_entity_registry_enabled_default_when_disabled(
+        self, sensor: InceptionLastReviewEventSensor, mock_coordinator: Mock
+    ) -> None:
+        """Test sensor registry enabled default when review events are disabled."""
+        mock_coordinator.review_events_global_enabled = False
+        assert not sensor.entity_registry_enabled_default
+
+    def test_entity_registry_enabled_default_when_enabled(
+        self, sensor: InceptionLastReviewEventSensor, mock_coordinator: Mock
+    ) -> None:
+        """Test sensor registry enabled default when review events are enabled."""
+        mock_coordinator.review_events_global_enabled = True
+        assert sensor.entity_registry_enabled_default
+
+    def test_handle_review_event(self, sensor: InceptionLastReviewEventSensor) -> None:
+        """Test handling a review event."""
+        # Create a mock event
+        event = Mock()
+        event.data = {
+            "event_id": "123",
+            "description": "Test event",
+            "message_value": 1000,
+            "message_category": "Access",
+            "message_description": "Card Access Granted",
+            "when": "2023-01-01T12:00:00Z",
+            "reference_time": "2023-01-01T12:00:00Z",
+            "who": "John Doe",
+            "who_id": "456",
+            "what": "Card 123",
+            "what_id": "789",
+            "where": "Front Door",
+            "where_id": "101",
+        }
+
+        # Handle the event
+        sensor._handle_review_event(event)
+
+        # Check the sensor state
+        assert sensor.native_value == "Card Access Granted"
+        assert sensor.extra_state_attributes == {
+            "event_id": "123",
+            "description": "Test event",
+            "message_value": 1000,
+            "message_category": "Access",
+            "when": "2023-01-01T12:00:00Z",
+            "reference_time": "2023-01-01T12:00:00Z",
+            "who": "John Doe",
+            "who_id": "456",
+            "what": "Card 123",
+            "what_id": "789",
+            "where": "Front Door",
+            "where_id": "101",
+        }
+
+    def test_handle_review_event_unknown_message(
+        self, sensor: InceptionLastReviewEventSensor
+    ) -> None:
+        """Test handling a review event with unknown message."""
+        # Create a mock event with unknown message
+        event = Mock()
+        event.data = {
+            "event_id": "123",
+            "description": "Test event",
+            "message_value": 9999,
+            "message_category": "Unknown",
+            "message_description": "Unknown",
+            "when": None,
+            "reference_time": None,
+            "who": None,
+            "who_id": None,
+            "what": None,
+            "what_id": None,
+            "where": None,
+            "where_id": None,
+        }
+
+        # Handle the event
+        sensor._handle_review_event(event)
+
+        # Check the sensor state shows unknown
+        assert sensor.native_value == "Unknown"
+
+        # Check all attributes are present
+        attributes = sensor.extra_state_attributes
+        assert attributes is not None
+        assert attributes["message_category"] == "Unknown"


### PR DESCRIPTION
- Creates diagnostic sensor showing last received review event message description
- All event data available as entity attributes (event_id, timestamps, who/what/where details)
- Sensor automatically disabled when review events switch is off
- Entity registry integration for dynamic enable/disable control
- Comprehensive test coverage for sensor functionality and state management

The sensor helps with debugging event reception and creating security dashboards.