### PR TITLE
Fix integration cleanup and prevent duplicate event callbacks

### DIFF
--- a/custom_components/inception/pyinception/api.py
+++ b/custom_components/inception/pyinception/api.py
@@ -466,6 +466,14 @@ class InceptionApiClient:
             with contextlib.suppress(asyncio.CancelledError):
                 await asyncio.gather(self.rest_task)
 
+        # Clear callback lists to prevent memory leaks
+        self.data_update_cbs.clear()
+        self.review_event_cbs.clear()
+
+        # Reset task references
+        self.rest_task = None
+        self._review_events_task = None
+
     async def _monitor_events_request(self, payload: Any) -> Any | None:
         """Monitor updates from the API."""
         try:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -2,15 +2,20 @@
 
 from __future__ import annotations
 
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
 from homeassistant.const import Platform
 
 from custom_components.inception import (
     PLATFORMS,
     async_reload_entry,
+    async_remove_entry,
     async_setup_entry,
     async_unload_entry,
 )
 from custom_components.inception.const import DOMAIN
+from custom_components.inception.pyinception.api import InceptionApiClient
 
 
 class TestInceptionIntegration:
@@ -40,3 +45,132 @@ class TestInceptionIntegration:
         assert callable(async_setup_entry)
         assert callable(async_unload_entry)
         assert callable(async_reload_entry)
+        assert callable(async_remove_entry)
+
+
+@pytest.mark.asyncio
+async def test_async_unload_entry_cleans_up_coordinator() -> None:
+    """Test that async_unload_entry properly cleans up the coordinator."""
+    # Create mock objects
+    mock_hass = Mock()
+    mock_entry = Mock()
+    mock_entry.entry_id = "test_entry_id"
+
+    # Create a mock coordinator
+    mock_coordinator = Mock()
+    mock_coordinator.async_unload = AsyncMock()
+
+    # Set up hass.data with the coordinator
+    mock_hass.data = {DOMAIN: {mock_entry.entry_id: mock_coordinator}}
+
+    # Mock async_unload_platforms to return True
+    mock_hass.config_entries.async_unload_platforms = AsyncMock(return_value=True)
+
+    # Call async_unload_entry
+    result = await async_unload_entry(mock_hass, mock_entry)
+
+    # Verify platforms were unloaded
+    mock_hass.config_entries.async_unload_platforms.assert_called_once_with(
+        mock_entry, PLATFORMS
+    )
+
+    # Verify coordinator was cleaned up
+    mock_coordinator.async_unload.assert_called_once()
+
+    # Verify coordinator was removed from hass.data
+    assert mock_entry.entry_id not in mock_hass.data[DOMAIN]
+
+    # Verify function returned True
+    assert result is True
+
+
+@pytest.mark.asyncio
+async def test_async_unload_entry_fails_if_platforms_fail() -> None:
+    """Test that async_unload_entry returns False if platform unload fails."""
+    # Create mock objects
+    mock_hass = Mock()
+    mock_entry = Mock()
+    mock_entry.entry_id = "test_entry_id"
+
+    # Create a mock coordinator
+    mock_coordinator = Mock()
+    mock_coordinator.async_unload = AsyncMock()
+
+    # Set up hass.data with the coordinator
+    mock_hass.data = {DOMAIN: {mock_entry.entry_id: mock_coordinator}}
+
+    # Mock async_unload_platforms to return False (failure)
+    mock_hass.config_entries.async_unload_platforms = AsyncMock(return_value=False)
+
+    # Call async_unload_entry
+    result = await async_unload_entry(mock_hass, mock_entry)
+
+    # Verify platforms were attempted to unload
+    mock_hass.config_entries.async_unload_platforms.assert_called_once_with(
+        mock_entry, PLATFORMS
+    )
+
+    # Verify coordinator was NOT cleaned up (since platforms failed)
+    mock_coordinator.async_unload.assert_not_called()
+
+    # Verify coordinator was NOT removed from hass.data
+    assert mock_entry.entry_id in mock_hass.data[DOMAIN]
+
+    # Verify function returned False
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_async_remove_entry_cleans_up_storage() -> None:
+    """Test that async_remove_entry removes stored settings."""
+    # Create mock objects
+    mock_hass = Mock()
+    mock_entry = Mock()
+    mock_entry.entry_id = "test_entry_id"
+
+    # Mock the Store class
+    mock_store = Mock()
+    mock_store.async_remove = AsyncMock()
+
+    # Patch Store in the __init__ module where it's imported
+    with patch("custom_components.inception.Store", return_value=mock_store):
+        # Call async_remove_entry
+        await async_remove_entry(mock_hass, mock_entry)
+
+        # Verify store was removed
+        mock_store.async_remove.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_api_client_close_clears_callbacks() -> None:
+    """Test that API client close method clears callback lists."""
+    # Create a mock session
+    mock_session = Mock()
+
+    # Create API client
+    api_client = InceptionApiClient(
+        token="test_token",
+        host="http://test.com",
+        session=mock_session,
+    )
+
+    # Add some mock callbacks
+    mock_callback1 = Mock()
+    mock_callback2 = Mock()
+    api_client.register_data_callback(mock_callback1)
+    api_client.register_review_event_callback(mock_callback2)
+
+    # Verify callbacks were added
+    assert len(api_client.data_update_cbs) == 1
+    assert len(api_client.review_event_cbs) == 1
+
+    # Close the API client
+    await api_client.close()
+
+    # Verify callbacks were cleared
+    assert len(api_client.data_update_cbs) == 0
+    assert len(api_client.review_event_cbs) == 0
+
+    # Verify task references were reset
+    assert api_client.rest_task is None
+    assert api_client._review_events_task is None


### PR DESCRIPTION
This commit addresses several resource cleanup issues and prevents duplicate callback registration:

1. Fixed async_unload_entry to properly clean up coordinator:
   - Calls coordinator.async_unload() to stop background tasks
   - Removes coordinator from hass.data to prevent memory leaks
   - Returns False if platform unload fails

2. Added async_remove_entry handler:
   - Removes stored review events settings when integration is deleted
   - Cleans up storage data on user deletion

3. Enhanced API client cleanup:
   - Clears callback lists (data_update_cbs, review_event_cbs)
   - Resets task references on close
   - Prevents callbacks from firing after shutdown

4. Prevented duplicate callback registration:
   - Added _callbacks_registered flag to coordinator
   - Only registers callbacks once even with multiple update calls
   - Resets flag on unload for proper cleanup

5. Added comprehensive tests:
   - Test coordinator cleanup on unload
   - Test storage cleanup on removal
   - Test API client callback clearing
   - Test duplicate callback prevention
   - Test cleanup failure handling

All background tasks (REST monitoring, review events) are now properly stopped when the integration is disabled, reloaded, or deleted.