### PR TITLE
Add Home Assistant diagnostics support

### DIFF
--- a/custom_components/inception/diagnostics.py
+++ b/custom_components/inception/diagnostics.py
@@ -18,6 +18,12 @@ if TYPE_CHECKING:
 
 TO_REDACT = {CONF_TOKEN, CONF_HOST}
 
+# `Info1` / `Info2` on entity state updates may carry sensitive data
+# (e.g. `Info1` on a UserState update is the user's current location name,
+# and `Info2` on an AreaState update is the user-count for that area).
+# Redact them from the diagnostics dump.
+EXTRA_FIELDS_TO_REDACT = {"Info1", "Info2"}
+
 
 def _summary_to_dict(summary: Any) -> dict[str, Any]:
     """Render a schema container to JSON-safe primitives."""
@@ -39,7 +45,9 @@ def _summary_to_dict(summary: Any) -> dict[str, Any]:
             entry["public_state"] = int(public_state)
         extra_fields = getattr(item, "extra_fields", None)
         if extra_fields is not None:
-            entry["extra_fields"] = dict(extra_fields)
+            entry["extra_fields"] = async_redact_data(
+                dict(extra_fields), EXTRA_FIELDS_TO_REDACT
+            )
         rendered[str(item_id)] = entry
     return rendered
 

--- a/custom_components/inception/diagnostics.py
+++ b/custom_components/inception/diagnostics.py
@@ -1,0 +1,73 @@
+"""Diagnostics support for Inception."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, is_dataclass
+from typing import TYPE_CHECKING, Any
+
+from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.const import CONF_HOST, CONF_TOKEN
+
+from .const import DOMAIN
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+
+    from .coordinator import InceptionUpdateCoordinator
+    from .data import InceptionConfigEntry
+
+TO_REDACT = {CONF_TOKEN, CONF_HOST}
+
+
+def _summary_to_dict(summary: Any) -> dict[str, Any]:
+    """Render a schema container to JSON-safe primitives."""
+    if summary is None:
+        return {}
+
+    items = getattr(summary, "items", None)
+    if not isinstance(items, dict):
+        return {}
+
+    rendered: dict[str, Any] = {}
+    for item_id, item in items.items():
+        entry: dict[str, Any] = {}
+        entity_info = getattr(item, "entity_info", None)
+        if entity_info is not None and is_dataclass(entity_info):
+            entry["entity_info"] = asdict(entity_info)
+        public_state = getattr(item, "public_state", None)
+        if public_state is not None:
+            entry["public_state"] = int(public_state)
+        extra_fields = getattr(item, "extra_fields", None)
+        if extra_fields is not None:
+            entry["extra_fields"] = dict(extra_fields)
+        rendered[str(item_id)] = entry
+    return rendered
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant,
+    entry: InceptionConfigEntry,
+) -> dict[str, Any]:
+    """Return diagnostics for a config entry."""
+    coordinator: InceptionUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    api_data = coordinator.data
+
+    return {
+        "entry": {
+            "title": entry.title,
+            "version": entry.version,
+            "data": async_redact_data(dict(entry.data), TO_REDACT),
+            "options": dict(entry.options),
+        },
+        "coordinator": {
+            "monitor_connected": coordinator.monitor_connected,
+            "review_events_global_enabled": coordinator.review_events_global_enabled,
+            "last_update_success": coordinator.last_update_success,
+        },
+        "api_data": {
+            "inputs": _summary_to_dict(getattr(api_data, "inputs", None)),
+            "doors": _summary_to_dict(getattr(api_data, "doors", None)),
+            "areas": _summary_to_dict(getattr(api_data, "areas", None)),
+            "outputs": _summary_to_dict(getattr(api_data, "outputs", None)),
+        },
+    }

--- a/tests/unit/test_diagnostics.py
+++ b/tests/unit/test_diagnostics.py
@@ -58,6 +58,27 @@ class TestSummaryToDict:
             },
         }
 
+    def test_info1_and_info2_are_redacted_in_extra_fields(self) -> None:
+        """`Info1`/`Info2` may contain sensitive data (user location, occupancy)."""
+        entry = SimpleNamespace(
+            entity_info=_FakeEntityInfo(ID="a1", Name="Area", ReportingID=1),
+            public_state=2048,
+            extra_fields={
+                "Info1": "Area will automatically Arm at 18:00",
+                "Info2": "3",
+                "LastStateChangeTime": "2026-04-16T00:00:00",
+            },
+        )
+        summary = _fake_summary({"a1": entry})
+
+        rendered = diagnostics._summary_to_dict(summary)
+
+        extras = rendered["a1"]["extra_fields"]
+        assert extras["Info1"] == "**REDACTED**"
+        assert extras["Info2"] == "**REDACTED**"
+        # Non-sensitive keys still pass through.
+        assert extras["LastStateChangeTime"] == "2026-04-16T00:00:00"
+
     def test_entry_with_missing_optional_fields(self) -> None:
         """An entry without public_state/extra_fields still renders."""
         entry = SimpleNamespace(

--- a/tests/unit/test_diagnostics.py
+++ b/tests/unit/test_diagnostics.py
@@ -1,0 +1,185 @@
+"""Test the Inception diagnostics support."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from custom_components.inception import diagnostics
+from custom_components.inception.const import DOMAIN
+
+
+@dataclass
+class _FakeEntityInfo:
+    """Minimal dataclass matching the shape used in summary entries."""
+
+    ID: str
+    Name: str
+    ReportingID: int
+
+
+def _fake_summary(entries: dict[str, Any] | None) -> SimpleNamespace:
+    """Build a SimpleNamespace that quacks like a schema summary container."""
+    return SimpleNamespace(items=entries or {})
+
+
+class TestSummaryToDict:
+    """Test the _summary_to_dict helper."""
+
+    def test_none_summary_returns_empty(self) -> None:
+        """None in yields empty dict out."""
+        assert diagnostics._summary_to_dict(None) == {}
+
+    def test_container_without_items_dict(self) -> None:
+        """A container whose .items is not a dict should be ignored."""
+        broken = SimpleNamespace(items="not a dict")
+        assert diagnostics._summary_to_dict(broken) == {}
+
+    def test_entry_serialised_with_all_fields(self) -> None:
+        """Entity info, public state and extra fields are rendered."""
+        entry = SimpleNamespace(
+            entity_info=_FakeEntityInfo(ID="abc", Name="Front Door", ReportingID=1),
+            public_state=2048,
+            extra_fields={"LastStateChangeTime": "2026-04-16T00:00:00"},
+        )
+        summary = _fake_summary({"abc": entry})
+
+        rendered = diagnostics._summary_to_dict(summary)
+
+        assert rendered == {
+            "abc": {
+                "entity_info": {"ID": "abc", "Name": "Front Door", "ReportingID": 1},
+                "public_state": 2048,
+                "extra_fields": {"LastStateChangeTime": "2026-04-16T00:00:00"},
+            },
+        }
+
+    def test_entry_with_missing_optional_fields(self) -> None:
+        """An entry without public_state/extra_fields still renders."""
+        entry = SimpleNamespace(
+            entity_info=_FakeEntityInfo(ID="x", Name="X", ReportingID=0),
+            public_state=None,
+            extra_fields=None,
+        )
+        summary = _fake_summary({"x": entry})
+
+        rendered = diagnostics._summary_to_dict(summary)
+
+        assert rendered == {
+            "x": {"entity_info": {"ID": "x", "Name": "X", "ReportingID": 0}}
+        }
+
+
+class TestAsyncGetConfigEntryDiagnostics:
+    """Test the diagnostics entry point."""
+
+    @pytest.mark.asyncio
+    async def test_redacts_sensitive_fields(self) -> None:
+        """Token and host are redacted; non-sensitive fields pass through."""
+        coordinator = SimpleNamespace(
+            data=SimpleNamespace(inputs=None, doors=None, areas=None, outputs=None),
+            monitor_connected=True,
+            review_events_global_enabled=False,
+            last_update_success=True,
+        )
+        entry = SimpleNamespace(
+            entry_id="entry-1",
+            title="Test Inception",
+            version=1,
+            data={
+                "host": "https://inception.example.com",
+                "token": "supersecret",
+                "name": "Test Inception",
+            },
+            options={"require_pin_code": True},
+        )
+        hass = SimpleNamespace(data={DOMAIN: {"entry-1": coordinator}})
+
+        # async_redact_data is sync, but the function is async; call directly.
+        result = await diagnostics.async_get_config_entry_diagnostics(
+            hass,  # type: ignore[arg-type]
+            entry,  # type: ignore[arg-type]
+        )
+
+        assert result["entry"]["data"]["token"] == "**REDACTED**"
+        assert result["entry"]["data"]["host"] == "**REDACTED**"
+        assert result["entry"]["data"]["name"] == "Test Inception"
+        assert result["entry"]["options"] == {"require_pin_code": True}
+
+    @pytest.mark.asyncio
+    async def test_renders_coordinator_state_and_api_data(self) -> None:
+        """Coordinator flags and API summaries are included."""
+        door = SimpleNamespace(
+            entity_info=_FakeEntityInfo(ID="d1", Name="Front", ReportingID=1),
+            public_state=1,
+            extra_fields={},
+        )
+        coordinator = SimpleNamespace(
+            data=SimpleNamespace(
+                inputs=_fake_summary(None),
+                doors=_fake_summary({"d1": door}),
+                areas=_fake_summary(None),
+                outputs=_fake_summary(None),
+            ),
+            monitor_connected=False,
+            review_events_global_enabled=True,
+            last_update_success=False,
+        )
+        entry = SimpleNamespace(
+            entry_id="entry-2",
+            title="T",
+            version=1,
+            data={"host": "h", "token": "t", "name": "n"},
+            options={},
+        )
+        hass = SimpleNamespace(data={DOMAIN: {"entry-2": coordinator}})
+
+        result = await diagnostics.async_get_config_entry_diagnostics(
+            hass,  # type: ignore[arg-type]
+            entry,  # type: ignore[arg-type]
+        )
+
+        assert result["coordinator"] == {
+            "monitor_connected": False,
+            "review_events_global_enabled": True,
+            "last_update_success": False,
+        }
+        assert "d1" in result["api_data"]["doors"]
+        assert result["api_data"]["doors"]["d1"]["public_state"] == 1
+        assert result["api_data"]["inputs"] == {}
+
+    @pytest.mark.asyncio
+    async def test_handles_missing_coordinator_data(self) -> None:
+        """A coordinator with data=None should not crash the diagnostics call."""
+        coordinator = SimpleNamespace(
+            data=None,
+            monitor_connected=False,
+            review_events_global_enabled=False,
+            last_update_success=True,
+        )
+        # AsyncMock here ensures accidental awaits on coordinator don't break the test.
+        coordinator.async_refresh = AsyncMock()
+        entry = SimpleNamespace(
+            entry_id="entry-3",
+            title="T",
+            version=1,
+            data={"host": "h", "token": "t"},
+            options={},
+        )
+        hass = SimpleNamespace(data={DOMAIN: {"entry-3": coordinator}})
+
+        result = await diagnostics.async_get_config_entry_diagnostics(
+            hass,  # type: ignore[arg-type]
+            entry,  # type: ignore[arg-type]
+        )
+
+        assert result["api_data"] == {
+            "inputs": {},
+            "doors": {},
+            "areas": {},
+            "outputs": {},
+        }


### PR DESCRIPTION
## Summary
- Adds `custom_components/inception/diagnostics.py` implementing the standard `async_get_config_entry_diagnostics` entry point so users (and bug reports) can download a useful state dump from Settings → Integrations.
- Token and host are redacted; coordinator flags (`monitor_connected`, `review_events_global_enabled`, `last_update_success`) and per-entity `public_state` / `extra_fields` for inputs, doors, areas, and outputs are included.

Implements Tier 1 #4 of the improvement analysis (low effort, high payoff for future debugging).

## Test plan
- [x] New unit tests in `tests/unit/test_diagnostics.py` cover: redaction of sensitive fields, container/entry rendering, graceful handling of `None` / missing fields
- [x] `scripts/lint` passes (ruff format + check)
- [x] `scripts/tests` passes locally (37/37 in touched areas; full suite unchanged)
- [x] Live smoke: download diagnostics from a configured Inception entry and confirm redacted output