### PR TITLE
Probe API protocol-version at setup

### DIFF
--- a/custom_components/inception/coordinator.py
+++ b/custom_components/inception/coordinator.py
@@ -55,6 +55,16 @@ class InceptionUpdateCoordinator(DataUpdateCoordinator[InceptionApiData]):
             EVENT_HOMEASSISTANT_STOP, self._async_shutdown
         )
 
+        # Probe the controller's API protocol version. The endpoint is
+        # unauthenticated and the docs recommend it as the first call before
+        # using any versioned endpoint. Any failure here is non-fatal — we
+        # still proceed with data fetching and let the normal error path
+        # surface auth / connectivity issues.
+        try:
+            await self.api.get_protocol_version()
+        except Exception as err:  # noqa: BLE001
+            LOGGER.debug("Protocol-version probe failed: %s", err)
+
         return await super()._async_setup()
 
     async def _async_shutdown(self, _event: Any) -> None:

--- a/custom_components/inception/pyinception/api.py
+++ b/custom_components/inception/pyinception/api.py
@@ -90,6 +90,7 @@ class InceptionApiClient:
         self._review_events_max_retry_delay: int = 300  # 5 minutes max
         self._rest_task_retry_count: int = 0
         self._rest_task_max_retry_delay: int = 300  # 5 minutes max
+        self.protocol_version: int | None = None
 
     T = TypeVar("T", DoorSummary, InputSummary, OutputSummary, AreaSummary)
 
@@ -118,6 +119,41 @@ class InceptionApiClient:
             path="/control/input",
         )
         return True
+
+    async def get_protocol_version(self) -> int | None:
+        """
+        Fetch the Inception API protocol version.
+
+        Returns the `ProtocolVersion` integer reported by the controller, or
+        `None` if the endpoint returns 404 (firmware too old to expose it).
+        Authentication is not required by the API for this endpoint, but the
+        auth header is sent anyway for simplicity — the server ignores it.
+        """
+        try:
+            response = await self.request(
+                method="get",
+                path="/protocol-version",
+                api_prefix="api",
+            )
+        except InceptionApiClientCommunicationError as err:
+            if "404" in str(err):
+                _LOGGER.warning(
+                    "Inception firmware does not expose /api/protocol-version; "
+                    "the firmware is likely older than v4.0"
+                )
+                self.protocol_version = None
+                return None
+            raise
+
+        if not isinstance(response, dict):
+            return None
+
+        version = response.get("ProtocolVersion")
+        if isinstance(version, int):
+            self.protocol_version = version
+            _LOGGER.info("Inception API protocol version: %d", version)
+            return version
+        return None
 
     async def connect(self) -> None:
         """Connect to the API."""
@@ -543,6 +579,7 @@ class InceptionApiClient:
         path: str,
         data: Any | None = None,
         api_timeout: aiohttp.ClientTimeout | None = None,
+        api_prefix: str = "api/v1",
     ) -> Any:
         """Get information from the API."""
         try:
@@ -556,10 +593,11 @@ class InceptionApiClient:
 
             # If path begins with a slash, remove it
             path = path.removeprefix("/")
+            prefix = api_prefix.strip("/")
 
             response = await self._session.request(
                 method=method,
-                url=f"{self._host}/api/v1/{path}",
+                url=f"{self._host}/{prefix}/{path}",
                 headers=headers,
                 json=data,
                 timeout=api_timeout,

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -608,3 +608,175 @@ class TestRestTaskBackoff:
 
         assert call_count == 1
         assert api_client._rest_task_retry_count == 1
+
+
+class _AwaitableValue:
+    """Minimal awaitable wrapper so session.request can be mocked synchronously."""
+
+    def __init__(self, value: Any) -> None:
+        self._value = value
+
+    def __await__(self) -> Any:
+        async def _inner() -> Any:
+            return self._value
+
+        return _inner().__await__()
+
+
+class TestProtocolVersion:
+    """Tests for the protocol-version probe."""
+
+    @pytest.fixture
+    def mock_session(self) -> Mock:
+        """Return a mocked aiohttp session."""
+        return Mock(spec=aiohttp.ClientSession)
+
+    @pytest.mark.asyncio
+    async def test_get_protocol_version_stores_integer(
+        self, mock_session: Mock
+    ) -> None:
+        """A 200 response with ProtocolVersion caches and returns the int."""
+        api_client = InceptionApiClient(
+            token="test-token",
+            host="http://test.example.com",
+            session=mock_session,
+        )
+        assert api_client.protocol_version is None
+
+        with patch.object(
+            api_client, "request", return_value={"ProtocolVersion": 11}
+        ) as mock_request:
+            version = await api_client.get_protocol_version()
+
+        assert version == 11
+        assert api_client.protocol_version == 11
+        mock_request.assert_awaited_once_with(
+            method="get",
+            path="/protocol-version",
+            api_prefix="api",
+        )
+
+    @pytest.mark.asyncio
+    async def test_get_protocol_version_404_returns_none(
+        self, mock_session: Mock
+    ) -> None:
+        """Old firmware returns 404; we swallow it and return None."""
+        api_client = InceptionApiClient(
+            token="t", host="http://test.example.com", session=mock_session
+        )
+        with patch.object(
+            api_client,
+            "request",
+            side_effect=InceptionApiClientCommunicationError(
+                "Error fetching information - 404, message='Not Found', url='...'"
+            ),
+        ):
+            version = await api_client.get_protocol_version()
+
+        assert version is None
+        assert api_client.protocol_version is None
+
+    @pytest.mark.asyncio
+    async def test_get_protocol_version_non_404_communication_error_raises(
+        self, mock_session: Mock
+    ) -> None:
+        """Connectivity failures (non-404) bubble up."""
+        api_client = InceptionApiClient(
+            token="t", host="http://test.example.com", session=mock_session
+        )
+        with (
+            patch.object(
+                api_client,
+                "request",
+                side_effect=InceptionApiClientCommunicationError(
+                    "Error fetching information - Cannot connect to host"
+                ),
+            ),
+            pytest.raises(InceptionApiClientCommunicationError),
+        ):
+            await api_client.get_protocol_version()
+
+    @pytest.mark.asyncio
+    async def test_get_protocol_version_malformed_response(
+        self, mock_session: Mock
+    ) -> None:
+        """A response without ProtocolVersion yields None, doesn't crash."""
+        api_client = InceptionApiClient(
+            token="t", host="http://test.example.com", session=mock_session
+        )
+        with patch.object(api_client, "request", return_value={"unexpected": "shape"}):
+            version = await api_client.get_protocol_version()
+
+        assert version is None
+
+    @pytest.mark.asyncio
+    async def test_get_protocol_version_non_dict_response(
+        self, mock_session: Mock
+    ) -> None:
+        """A non-dict response (e.g. list) yields None rather than raising."""
+        api_client = InceptionApiClient(
+            token="t", host="http://test.example.com", session=mock_session
+        )
+        with patch.object(api_client, "request", return_value=[1, 2, 3]):
+            version = await api_client.get_protocol_version()
+
+        assert version is None
+
+
+class TestRequestApiPrefix:
+    """Tests for the api_prefix argument to request()."""
+
+    @pytest.mark.asyncio
+    async def test_request_uses_custom_api_prefix(self) -> None:
+        """The api_prefix argument overrides the default v1 path prefix."""
+        mock_session = Mock(spec=aiohttp.ClientSession)
+        mock_response = Mock()
+        mock_response.status = 200
+        mock_response.raise_for_status.return_value = None
+
+        async def _json(content_type: Any = None) -> dict[str, int]:  # noqa: ARG001
+            return {"ProtocolVersion": 8}
+
+        mock_response.json = _json
+        mock_session.request = Mock(return_value=_AwaitableValue(mock_response))
+
+        client = InceptionApiClient(
+            token="t",
+            host="http://h.test",
+            session=mock_session,
+        )
+
+        result = await client.request(
+            method="get",
+            path="/protocol-version",
+            api_prefix="api",
+        )
+
+        assert result == {"ProtocolVersion": 8}
+        called_url = mock_session.request.call_args.kwargs["url"]
+        assert called_url == "http://h.test/api/protocol-version"
+
+    @pytest.mark.asyncio
+    async def test_request_default_api_prefix_is_v1(self) -> None:
+        """Default prefix remains api/v1 so existing callers are unchanged."""
+        mock_session = Mock(spec=aiohttp.ClientSession)
+        mock_response = Mock()
+        mock_response.status = 200
+        mock_response.raise_for_status.return_value = None
+
+        async def _json(content_type: Any = None) -> dict[str, str]:  # noqa: ARG001
+            return {}
+
+        mock_response.json = _json
+        mock_session.request = Mock(return_value=_AwaitableValue(mock_response))
+
+        client = InceptionApiClient(
+            token="t",
+            host="http://h.test",
+            session=mock_session,
+        )
+
+        await client.request(method="get", path="/control/input")
+
+        called_url = mock_session.request.call_args.kwargs["url"]
+        assert called_url == "http://h.test/api/v1/control/input"


### PR DESCRIPTION
## Summary
- Adds `InceptionApiClient.get_protocol_version()` which calls the unauthenticated `/api/protocol-version` endpoint — the pre-flight check recommended by the Inner Range REST API docs before using versioned endpoints.
- The coordinator now invokes the probe once during `_async_setup`; any failure is logged but non-fatal, and a 404 (firmware predates the endpoint) is handled explicitly.
- `InceptionApiClient.request()` gains an `api_prefix` kwarg (defaults to `api/v1`) so the versionless `/api/protocol-version` path can reuse the existing request plumbing.
- The cached `protocol_version` is stored on the client so future feature-gating (e.g. protocol v11 `generate-unused-pin`) can read it without another round-trip.

Implements Tier 1 #2 of the improvement analysis.

## Test plan
- [x] New `TestProtocolVersion` + `TestRequestApiPrefix` suites in `tests/unit/test_api.py`: 200 response caching, 404 -> None, non-404 errors propagate, malformed / non-dict responses tolerated, URL correctness verified for both prefixes
- [x] `scripts/lint` passes
- [x] `scripts/tests` passes locally (54/54 across touched areas; full suite unchanged)
- [ ] Live smoke: confirm version is logged on startup against a real controller