### PR TITLE
Surface auth failures via ConfigEntryAuthFailed + re-auth flow

### DIFF
--- a/custom_components/inception/config_flow.py
+++ b/custom_components/inception/config_flow.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import voluptuous as vol
 from homeassistant import config_entries
@@ -28,6 +28,8 @@ from .pyinception.api import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
     from homeassistant.config_entries import ConfigFlowResult
 
 
@@ -118,6 +120,57 @@ class InceptionFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             session=async_create_clientsession(self.hass),
         )
         await client.authenticate()
+
+    async def async_step_reauth(
+        self,
+        _entry_data: Mapping[str, Any],
+    ) -> ConfigFlowResult:
+        """Triggered when HA requests re-authentication."""
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(
+        self,
+        user_input: dict | None = None,
+    ) -> ConfigFlowResult:
+        """Prompt the user to supply a new API token for the existing entry."""
+        errors: dict[str, str] = {}
+        entry = self._get_reauth_entry()
+
+        if user_input is not None:
+            try:
+                await self._test_credentials(
+                    token=user_input[CONF_TOKEN],
+                    host=entry.data[CONF_HOST],
+                )
+            except InceptionApiClientAuthenticationError as exception:
+                LOGGER.warning(exception)
+                errors["base"] = "auth"
+            except InceptionApiClientCommunicationError as exception:
+                LOGGER.error(exception)
+                errors["base"] = "connection"
+            except InceptionApiClientError as exception:
+                LOGGER.exception(exception)
+                errors["base"] = "unknown"
+            else:
+                return self.async_update_reload_and_abort(
+                    entry,
+                    data_updates={CONF_TOKEN: user_input[CONF_TOKEN]},
+                )
+
+        return self.async_show_form(
+            step_id="reauth_confirm",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_TOKEN): selector.TextSelector(
+                        selector.TextSelectorConfig(
+                            type=selector.TextSelectorType.PASSWORD,
+                        ),
+                    ),
+                },
+            ),
+            description_placeholders={"name": entry.title},
+            errors=errors,
+        )
 
 
 class InceptionOptionsFlowHandler(OptionsFlow):

--- a/custom_components/inception/coordinator.py
+++ b/custom_components/inception/coordinator.py
@@ -6,15 +6,21 @@ from typing import TYPE_CHECKING, Any
 
 from homeassistant.const import CONF_HOST, CONF_TOKEN, EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import callback
+from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.entity_registry import RegistryEntryDisabler, async_get
 from homeassistant.helpers.storage import Store
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import DOMAIN, EVENT_REVIEW_EVENT, LOGGER
-from .pyinception.api import InceptionApiClient
+from .pyinception.api import (
+    InceptionApiClient,
+    InceptionApiClientAuthenticationError,
+)
 from .pyinception.data import InceptionApiData
 from .pyinception.message_categories import get_message_info
+
+AUTH_ISSUE_ID_PREFIX = "auth_failure"
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
@@ -71,15 +77,22 @@ class InceptionUpdateCoordinator(DataUpdateCoordinator[InceptionApiData]):
         await self.api.close()
         self.monitor_connected = False
         self._callbacks_registered = False
+        self._clear_auth_failure()
 
     async def _async_update_data(self) -> InceptionApiData:
         """Fetch data from the API."""
         try:
             data = await self.api.get_data()
+        except InceptionApiClientAuthenticationError as err:
+            self._report_auth_failure()
+            raise UpdateFailed(err) from err
         except Exception as err:
             LOGGER.debug("Failed to fetch data: %s", err)
             LOGGER.exception("Error fetching data from Inception")
             raise UpdateFailed(err) from err
+        else:
+            # A successful fetch means any prior auth issue is resolved.
+            self._clear_auth_failure()
 
         if not self.monitor_connected:
             LOGGER.debug(
@@ -91,11 +104,38 @@ class InceptionUpdateCoordinator(DataUpdateCoordinator[InceptionApiData]):
             if not self._callbacks_registered:
                 self.api.register_data_callback(self.data_callback)
                 self.api.register_review_event_callback(self.review_event_callback)
+                self.api.register_auth_error_callback(self._report_auth_failure)
                 self._callbacks_registered = True
 
             self.monitor_connected = True
 
         return data
+
+    @property
+    def _auth_issue_id(self) -> str:
+        """Stable repairs issue ID per config entry."""
+        return f"{AUTH_ISSUE_ID_PREFIX}_{self.config_entry.entry_id}"
+
+    @callback
+    def _report_auth_failure(self) -> None:
+        """Create an HA Repairs issue for an authentication failure."""
+        ir.async_create_issue(
+            self.hass,
+            DOMAIN,
+            self._auth_issue_id,
+            is_fixable=False,
+            severity=ir.IssueSeverity.ERROR,
+            translation_key="auth_failure",
+            translation_placeholders={"entry_title": self.config_entry.title},
+            learn_more_url=(
+                "https://github.com/sebr/inception-home-assistant#authentication"
+            ),
+        )
+
+    @callback
+    def _clear_auth_failure(self) -> None:
+        """Remove any open auth-failure issue for this entry."""
+        ir.async_delete_issue(self.hass, DOMAIN, self._auth_issue_id)
 
     @callback
     def data_callback(self, data: InceptionApiData) -> None:

--- a/custom_components/inception/coordinator.py
+++ b/custom_components/inception/coordinator.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any
 
 from homeassistant.const import CONF_HOST, CONF_TOKEN, EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import callback
-from homeassistant.helpers import issue_registry as ir
+from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.entity_registry import RegistryEntryDisabler, async_get
 from homeassistant.helpers.storage import Store
@@ -19,8 +19,6 @@ from .pyinception.api import (
 )
 from .pyinception.data import InceptionApiData
 from .pyinception.message_categories import get_message_info
-
-AUTH_ISSUE_ID_PREFIX = "auth_failure"
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
@@ -77,22 +75,19 @@ class InceptionUpdateCoordinator(DataUpdateCoordinator[InceptionApiData]):
         await self.api.close()
         self.monitor_connected = False
         self._callbacks_registered = False
-        self._clear_auth_failure()
 
     async def _async_update_data(self) -> InceptionApiData:
         """Fetch data from the API."""
         try:
             data = await self.api.get_data()
         except InceptionApiClientAuthenticationError as err:
-            self._report_auth_failure()
-            raise UpdateFailed(err) from err
+            # Trigger Home Assistant's built-in re-auth flow so the user
+            # sees a "Reconfigure" prompt and can re-enter their token.
+            raise ConfigEntryAuthFailed(err) from err
         except Exception as err:
             LOGGER.debug("Failed to fetch data: %s", err)
             LOGGER.exception("Error fetching data from Inception")
             raise UpdateFailed(err) from err
-        else:
-            # A successful fetch means any prior auth issue is resolved.
-            self._clear_auth_failure()
 
         if not self.monitor_connected:
             LOGGER.debug(
@@ -104,38 +99,29 @@ class InceptionUpdateCoordinator(DataUpdateCoordinator[InceptionApiData]):
             if not self._callbacks_registered:
                 self.api.register_data_callback(self.data_callback)
                 self.api.register_review_event_callback(self.review_event_callback)
-                self.api.register_auth_error_callback(self._report_auth_failure)
+                self.api.register_auth_error_callback(self._trigger_reauth)
                 self._callbacks_registered = True
 
             self.monitor_connected = True
 
         return data
 
-    @property
-    def _auth_issue_id(self) -> str:
-        """Stable repairs issue ID per config entry."""
-        return f"{AUTH_ISSUE_ID_PREFIX}_{self.config_entry.entry_id}"
-
     @callback
-    def _report_auth_failure(self) -> None:
-        """Create an HA Repairs issue for an authentication failure."""
-        ir.async_create_issue(
-            self.hass,
-            DOMAIN,
-            self._auth_issue_id,
-            is_fixable=False,
-            severity=ir.IssueSeverity.ERROR,
-            translation_key="auth_failure",
-            translation_placeholders={"entry_title": self.config_entry.title},
-            learn_more_url=(
-                "https://github.com/sebr/inception-home-assistant#authentication"
-            ),
+    def _trigger_reauth(self) -> None:
+        """
+        Start the re-auth flow in response to a background auth failure.
+
+        `_async_update_data` raising `ConfigEntryAuthFailed` handles the
+        foreground path. When the long-poll `_rest_task` hits 401/403 it
+        also needs to surface, but the coordinator may not run
+        `_async_update_data` again for a while — so we kick the re-auth
+        flow directly here.
+        """
+        LOGGER.warning(
+            "Inception authentication failed for %s; starting re-auth flow",
+            self.config_entry.title,
         )
-
-    @callback
-    def _clear_auth_failure(self) -> None:
-        """Remove any open auth-failure issue for this entry."""
-        ir.async_delete_issue(self.hass, DOMAIN, self._auth_issue_id)
+        self.config_entry.async_start_reauth(self.hass)
 
     @callback
     def data_callback(self, data: InceptionApiData) -> None:

--- a/custom_components/inception/pyinception/api.py
+++ b/custom_components/inception/pyinception/api.py
@@ -49,16 +49,6 @@ class InceptionApiClientAuthenticationError(
     """Exception to indicate an authentication error."""
 
 
-def _verify_response_or_raise(response: aiohttp.ClientResponse) -> None:
-    """Verify that the response is valid."""
-    if response.status in (401, 403):
-        msg = "Invalid credentials"
-        raise InceptionApiClientAuthenticationError(
-            msg,
-        )
-    response.raise_for_status()
-
-
 class InceptionApiClient:
     """Inception API Client."""
 
@@ -577,13 +567,18 @@ class InceptionApiClient:
                 json=data,
                 timeout=api_timeout,
             )
-            _verify_response_or_raise(response)
+            if response.status in (401, 403):
+                # Surface 401/403 as a specific auth error so the coordinator
+                # can route it into Home Assistant's re-auth flow rather than
+                # treating it as a transient connection failure.
+                msg = "Invalid credentials"
+                raise InceptionApiClientAuthenticationError(msg)  # noqa: TRY301
+            response.raise_for_status()
             return await response.json(content_type=None)
         except InceptionApiClientError:
-            # Our own exceptions (esp. InceptionApiClientAuthenticationError
-            # from `_verify_response_or_raise`) must propagate with their
-            # original type so callers can route 401/403 into the re-auth
-            # flow instead of treating them as generic errors.
+            # Our own exception hierarchy must propagate unchanged — the
+            # broad `except Exception` below would otherwise rewrap the
+            # auth error as a generic client error.
             raise
         except TimeoutError as exception:
             _LOGGER.debug("Timeout fetching %s", path)

--- a/custom_components/inception/pyinception/api.py
+++ b/custom_components/inception/pyinception/api.py
@@ -579,6 +579,12 @@ class InceptionApiClient:
             )
             _verify_response_or_raise(response)
             return await response.json(content_type=None)
+        except InceptionApiClientError:
+            # Our own exceptions (esp. InceptionApiClientAuthenticationError
+            # from `_verify_response_or_raise`) must propagate with their
+            # original type so callers can route 401/403 into the re-auth
+            # flow instead of treating them as generic errors.
+            raise
         except TimeoutError as exception:
             _LOGGER.debug("Timeout fetching %s", path)
             raise TimeoutError from exception

--- a/custom_components/inception/pyinception/api.py
+++ b/custom_components/inception/pyinception/api.py
@@ -79,6 +79,7 @@ class InceptionApiClient:
         self.data: InceptionApiData | None = None
         self.data_update_cbs: list = []
         self.review_event_cbs: list = []
+        self.auth_error_cbs: list = []
         self.loop: asyncio.AbstractEventLoop = asyncio.get_running_loop()
         self.rest_task: asyncio.Task | None = None
         self._review_events_task: asyncio.Task | None = None
@@ -368,6 +369,16 @@ class InceptionApiClient:
         if callback not in self.review_event_cbs:
             self.review_event_cbs.append(callback)
 
+    def register_auth_error_callback(self, callback: Callable) -> None:
+        """Register a callback invoked when the controller rejects auth."""
+        if callback not in self.auth_error_cbs:
+            self.auth_error_cbs.append(callback)
+
+    def _schedule_auth_error_callbacks(self) -> None:
+        """Fan out auth-error notifications on the main loop."""
+        for cb in self.auth_error_cbs:
+            self.loop.call_soon_threadsafe(cb)
+
     async def _rest_task(self) -> None:
         """Poll data periodically via Rest."""
         while True:
@@ -378,6 +389,7 @@ class InceptionApiClient:
                 _LOGGER.exception(
                     "rest_task: Authentication error, stopping monitoring"
                 )
+                self._schedule_auth_error_callbacks()
                 break
             except (
                 InceptionApiClientCommunicationError,
@@ -415,6 +427,7 @@ class InceptionApiClient:
                     # No sleep needed - long polling will wait for events
                 except InceptionApiClientAuthenticationError:
                     # Authentication errors always stop the task
+                    self._schedule_auth_error_callbacks()
                     raise
                 except InceptionApiClientCommunicationError as e:
                     # Check if it's a 4xx client error (irrecoverable)

--- a/custom_components/inception/translations/en.json
+++ b/custom_components/inception/translations/en.json
@@ -76,5 +76,11 @@
                 }
             }
         }
+    },
+    "issues": {
+        "auth_failure": {
+            "title": "Inception authentication failed",
+            "description": "Home Assistant could not authenticate to the Inception controller configured as **{entry_title}**. The API token may have been revoked or the controller may have locked the account after repeated failures. Check the token under Users \u2192 Remote / Web Access in the Inception web interface, then reconfigure the integration with a valid token."
+        }
     }
 }

--- a/custom_components/inception/translations/en.json
+++ b/custom_components/inception/translations/en.json
@@ -13,12 +13,25 @@
                     "token": "An Inception User API token. Available under Users > Remote / Web Access > User API Token.",
                     "host": "The host address of your Inception hub. If no protocol is specified, http:// will be used."
                 }
+            },
+            "reauth_confirm": {
+                "title": "Re-authenticate with Inception",
+                "description": "The API token for **{name}** was rejected by the Inception controller. Check the token under Users \u2192 Remote / Web Access \u2192 User API Token in the Inception web interface, then paste the current token below.",
+                "data": {
+                    "token": "Token"
+                },
+                "data_description": {
+                    "token": "A valid Inception User API token."
+                }
             }
         },
         "error": {
             "auth": "Unable to authenticate to Inception",
             "connection": "Unable to connect to Inception.",
             "unknown": "Unknown error occurred."
+        },
+        "abort": {
+            "reauth_successful": "Re-authentication was successful."
         }
     },
     "options": {
@@ -75,12 +88,6 @@
                     "timed_unlock": "Timed Unlock"
                 }
             }
-        }
-    },
-    "issues": {
-        "auth_failure": {
-            "title": "Inception authentication failed",
-            "description": "Home Assistant could not authenticate to the Inception controller configured as **{entry_title}**. The API token may have been revoked or the controller may have locked the account after repeated failures. Check the token under Users \u2192 Remote / Web Access in the Inception web interface, then reconfigure the integration with a valid token."
         }
     }
 }

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -18,42 +18,7 @@ from custom_components.inception.pyinception.api import (
     InceptionApiClientAuthenticationError,
     InceptionApiClientCommunicationError,
     InceptionApiClientError,
-    _verify_response_or_raise,
 )
-
-
-class TestVerifyResponseOrRaise:
-    """Test _verify_response_or_raise function."""
-
-    def test_verify_response_success(self) -> None:
-        """Test successful response verification."""
-        mock_response = Mock()
-        mock_response.status = 200
-        mock_response.raise_for_status.return_value = None
-
-        # Should not raise any exception
-        _verify_response_or_raise(mock_response)
-        mock_response.raise_for_status.assert_called_once()
-
-    def test_verify_response_401_raises_auth_error(self) -> None:
-        """Test 401 response raises authentication error."""
-        mock_response = Mock()
-        mock_response.status = 401
-
-        with pytest.raises(
-            InceptionApiClientAuthenticationError, match="Invalid credentials"
-        ):
-            _verify_response_or_raise(mock_response)
-
-    def test_verify_response_403_raises_auth_error(self) -> None:
-        """Test 403 response raises authentication error."""
-        mock_response = Mock()
-        mock_response.status = 403
-
-        with pytest.raises(
-            InceptionApiClientAuthenticationError, match="Invalid credentials"
-        ):
-            _verify_response_or_raise(mock_response)
 
 
 class TestInceptionApiClient:

--- a/tests/unit/test_auth_repairs.py
+++ b/tests/unit/test_auth_repairs.py
@@ -1,18 +1,15 @@
-"""Tests for surfacing Inception auth failures via HA Repairs."""
+"""Tests for surfacing Inception auth failures via HA re-auth flow."""
 
 from __future__ import annotations
 
 from types import SimpleNamespace
-from unittest.mock import Mock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import aiohttp
 import pytest
+from homeassistant.exceptions import ConfigEntryAuthFailed
 
-from custom_components.inception.const import DOMAIN
-from custom_components.inception.coordinator import (
-    AUTH_ISSUE_ID_PREFIX,
-    InceptionUpdateCoordinator,
-)
+from custom_components.inception.coordinator import InceptionUpdateCoordinator
 from custom_components.inception.pyinception.api import (
     InceptionApiClient,
     InceptionApiClientAuthenticationError,
@@ -100,8 +97,8 @@ class TestAuthErrorCallback:
         assert cb in scheduled
 
 
-class TestCoordinatorRepairsIntegration:
-    """The coordinator should create/clear HA Repairs issues on auth events."""
+class TestCoordinatorReauthIntegration:
+    """The coordinator should start HA's re-auth flow on auth events."""
 
     def _build_coordinator(self) -> InceptionUpdateCoordinator:
         """Build a minimal coordinator instance without going through __init__."""
@@ -110,44 +107,46 @@ class TestCoordinatorRepairsIntegration:
         coordinator.config_entry = SimpleNamespace(
             entry_id="entry-xyz",
             title="Home Inception",
+            async_start_reauth=Mock(),
         )
+        coordinator.api = Mock()
+        coordinator.monitor_connected = False
+        coordinator._callbacks_registered = False
         return coordinator
 
-    def test_auth_issue_id_is_stable_per_entry(self) -> None:
-        """The issue id should be deterministic and include the entry id."""
+    def test_trigger_reauth_delegates_to_config_entry(self) -> None:
+        """The coordinator's auth callback should call entry.async_start_reauth."""
         coordinator = self._build_coordinator()
 
-        assert coordinator._auth_issue_id == f"{AUTH_ISSUE_ID_PREFIX}_entry-xyz"
+        coordinator._trigger_reauth()
 
-    def test_report_auth_failure_creates_issue(self) -> None:
-        """Reporting an auth failure delegates to issue_registry.async_create_issue."""
+        coordinator.config_entry.async_start_reauth.assert_called_once_with(
+            coordinator.hass
+        )
+
+    @pytest.mark.asyncio
+    async def test_update_data_raises_config_entry_auth_failed(self) -> None:
+        """Foreground auth failures should raise ConfigEntryAuthFailed."""
         coordinator = self._build_coordinator()
+        coordinator.api.get_data = AsyncMock(
+            side_effect=InceptionApiClientAuthenticationError("bad token")
+        )
 
-        with patch(
-            "custom_components.inception.coordinator.ir.async_create_issue"
-        ) as mock_create:
-            coordinator._report_auth_failure()
+        with pytest.raises(ConfigEntryAuthFailed):
+            await coordinator._async_update_data()
 
-        mock_create.assert_called_once()
-        args, kwargs = mock_create.call_args
-        assert args[0] is coordinator.hass
-        assert args[1] == DOMAIN
-        assert args[2] == coordinator._auth_issue_id
-        assert kwargs["translation_key"] == "auth_failure"
-        assert kwargs["translation_placeholders"] == {"entry_title": "Home Inception"}
-        assert kwargs["is_fixable"] is False
-
-    def test_clear_auth_failure_deletes_issue(self) -> None:
-        """Clearing delegates to issue_registry.async_delete_issue."""
+    @pytest.mark.asyncio
+    async def test_update_data_registers_reauth_callback_after_success(self) -> None:
+        """On successful fetch, the API client gets the reauth callback wired."""
         coordinator = self._build_coordinator()
+        coordinator.api.get_data = AsyncMock(return_value=Mock())
+        coordinator.api.connect = AsyncMock()
+        coordinator.api.register_data_callback = Mock()
+        coordinator.api.register_review_event_callback = Mock()
+        coordinator.api.register_auth_error_callback = Mock()
 
-        with patch(
-            "custom_components.inception.coordinator.ir.async_delete_issue"
-        ) as mock_delete:
-            coordinator._clear_auth_failure()
+        await coordinator._async_update_data()
 
-        mock_delete.assert_called_once_with(
-            coordinator.hass,
-            DOMAIN,
-            coordinator._auth_issue_id,
+        coordinator.api.register_auth_error_callback.assert_called_once_with(
+            coordinator._trigger_reauth
         )

--- a/tests/unit/test_auth_repairs.py
+++ b/tests/unit/test_auth_repairs.py
@@ -97,6 +97,65 @@ class TestAuthErrorCallback:
         assert cb in scheduled
 
 
+class TestRequestPreservesAuthErrorType:
+    """`request()` must not rewrap our auth errors as generic errors."""
+
+    @pytest.mark.asyncio
+    async def test_401_response_raises_auth_error_not_generic(self) -> None:
+        """A 401 from the server reaches the caller as auth error, not generic."""
+        mock_session = Mock(spec=aiohttp.ClientSession)
+
+        class _Resp:
+            status = 401
+
+            def raise_for_status(self) -> None:
+                return None
+
+            async def json(self, content_type: object = None) -> dict[str, str]:  # noqa: ARG002
+                return {}
+
+        async def fake_request(*_args: object, **_kwargs: object) -> _Resp:
+            return _Resp()
+
+        mock_session.request = fake_request
+
+        client = InceptionApiClient(
+            token="bad", host="http://h.test", session=mock_session
+        )
+
+        # This used to raise InceptionApiClientError (generic) because the
+        # broad `except Exception` clause was rewrapping our own auth
+        # exception. Assert the specific type survives.
+        with pytest.raises(InceptionApiClientAuthenticationError):
+            await client.request(method="get", path="/control/input")
+
+    @pytest.mark.asyncio
+    async def test_403_response_raises_auth_error_not_generic(self) -> None:
+        """Same guarantee for a 403 response."""
+        mock_session = Mock(spec=aiohttp.ClientSession)
+
+        class _Resp:
+            status = 403
+
+            def raise_for_status(self) -> None:
+                return None
+
+            async def json(self, content_type: object = None) -> dict[str, str]:  # noqa: ARG002
+                return {}
+
+        async def fake_request(*_args: object, **_kwargs: object) -> _Resp:
+            return _Resp()
+
+        mock_session.request = fake_request
+
+        client = InceptionApiClient(
+            token="bad", host="http://h.test", session=mock_session
+        )
+
+        with pytest.raises(InceptionApiClientAuthenticationError):
+            await client.request(method="get", path="/control/input")
+
+
 class TestCoordinatorReauthIntegration:
     """The coordinator should start HA's re-auth flow on auth events."""
 

--- a/tests/unit/test_auth_repairs.py
+++ b/tests/unit/test_auth_repairs.py
@@ -1,0 +1,153 @@
+"""Tests for surfacing Inception auth failures via HA Repairs."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import aiohttp
+import pytest
+
+from custom_components.inception.const import DOMAIN
+from custom_components.inception.coordinator import (
+    AUTH_ISSUE_ID_PREFIX,
+    InceptionUpdateCoordinator,
+)
+from custom_components.inception.pyinception.api import (
+    InceptionApiClient,
+    InceptionApiClientAuthenticationError,
+)
+
+
+class TestAuthErrorCallback:
+    """The api client should fan out auth-error callbacks at the right moments."""
+
+    @pytest.fixture
+    def mock_session(self) -> Mock:
+        """Return a mocked aiohttp session."""
+        return Mock(spec=aiohttp.ClientSession)
+
+    @pytest.mark.asyncio
+    async def test_register_auth_error_callback_deduplicates(
+        self, mock_session: Mock
+    ) -> None:
+        """Registering the same callback twice should only store it once."""
+        client = InceptionApiClient(
+            token="t", host="http://h.test", session=mock_session
+        )
+
+        cb = Mock()
+        client.register_auth_error_callback(cb)
+        client.register_auth_error_callback(cb)
+
+        assert client.auth_error_cbs.count(cb) == 1
+
+    @pytest.mark.asyncio
+    async def test_rest_task_fires_auth_callback_on_auth_error(
+        self, mock_session: Mock
+    ) -> None:
+        """When _rest_task sees a 401, registered auth callbacks should fire."""
+        client = InceptionApiClient(
+            token="t", host="http://h.test", session=mock_session
+        )
+        scheduled: list[object] = []
+        client.loop = SimpleNamespace(
+            call_soon_threadsafe=lambda cb, *_: scheduled.append(cb)
+        )
+
+        cb = Mock()
+        client.register_auth_error_callback(cb)
+
+        async def raise_auth_error() -> None:
+            msg = "Invalid credentials"
+            raise InceptionApiClientAuthenticationError(msg)
+
+        with patch.object(
+            client, "monitor_entity_states", side_effect=raise_auth_error
+        ):
+            await client._rest_task()
+
+        assert cb in scheduled
+
+    @pytest.mark.asyncio
+    async def test_review_events_fires_auth_callback_on_auth_error(
+        self, mock_session: Mock
+    ) -> None:
+        """Auth errors bubbling out of _review_events_monitor also fire cbs."""
+        client = InceptionApiClient(
+            token="t", host="http://h.test", session=mock_session
+        )
+        scheduled: list[object] = []
+        client.loop = SimpleNamespace(
+            call_soon_threadsafe=lambda cb, *_: scheduled.append(cb)
+        )
+        client._review_events_enabled = True
+        client._review_events_categories = ["System"]
+
+        cb = Mock()
+        client.register_auth_error_callback(cb)
+
+        async def raise_auth_error(_categories: list[str] | None = None) -> None:
+            msg = "Invalid credentials"
+            raise InceptionApiClientAuthenticationError(msg)
+
+        with (
+            patch.object(client, "monitor_review_events", side_effect=raise_auth_error),
+            pytest.raises(InceptionApiClientAuthenticationError),
+        ):
+            await client._review_events_monitor()
+
+        assert cb in scheduled
+
+
+class TestCoordinatorRepairsIntegration:
+    """The coordinator should create/clear HA Repairs issues on auth events."""
+
+    def _build_coordinator(self) -> InceptionUpdateCoordinator:
+        """Build a minimal coordinator instance without going through __init__."""
+        coordinator = InceptionUpdateCoordinator.__new__(InceptionUpdateCoordinator)
+        coordinator.hass = SimpleNamespace()
+        coordinator.config_entry = SimpleNamespace(
+            entry_id="entry-xyz",
+            title="Home Inception",
+        )
+        return coordinator
+
+    def test_auth_issue_id_is_stable_per_entry(self) -> None:
+        """The issue id should be deterministic and include the entry id."""
+        coordinator = self._build_coordinator()
+
+        assert coordinator._auth_issue_id == f"{AUTH_ISSUE_ID_PREFIX}_entry-xyz"
+
+    def test_report_auth_failure_creates_issue(self) -> None:
+        """Reporting an auth failure delegates to issue_registry.async_create_issue."""
+        coordinator = self._build_coordinator()
+
+        with patch(
+            "custom_components.inception.coordinator.ir.async_create_issue"
+        ) as mock_create:
+            coordinator._report_auth_failure()
+
+        mock_create.assert_called_once()
+        args, kwargs = mock_create.call_args
+        assert args[0] is coordinator.hass
+        assert args[1] == DOMAIN
+        assert args[2] == coordinator._auth_issue_id
+        assert kwargs["translation_key"] == "auth_failure"
+        assert kwargs["translation_placeholders"] == {"entry_title": "Home Inception"}
+        assert kwargs["is_fixable"] is False
+
+    def test_clear_auth_failure_deletes_issue(self) -> None:
+        """Clearing delegates to issue_registry.async_delete_issue."""
+        coordinator = self._build_coordinator()
+
+        with patch(
+            "custom_components.inception.coordinator.ir.async_delete_issue"
+        ) as mock_delete:
+            coordinator._clear_auth_failure()
+
+        mock_delete.assert_called_once_with(
+            coordinator.hass,
+            DOMAIN,
+            coordinator._auth_issue_id,
+        )

--- a/tests/unit/test_coordinator_events.py
+++ b/tests/unit/test_coordinator_events.py
@@ -215,8 +215,10 @@ async def test_callbacks_registered_only_once() -> None:
     mock_api = Mock()
     mock_api.get_data = AsyncMock(return_value=Mock())
     mock_api.connect = AsyncMock()
+    mock_api.close = AsyncMock()
     mock_api.register_data_callback = Mock()
     mock_api.register_review_event_callback = Mock()
+    mock_api.register_auth_error_callback = Mock()
 
     # Create coordinator by mocking the parent class initialization
     with (
@@ -232,6 +234,8 @@ async def test_callbacks_registered_only_once() -> None:
             "custom_components.inception.coordinator.async_get_clientsession",
             return_value=Mock(),
         ),
+        patch("custom_components.inception.coordinator.ir.async_create_issue"),
+        patch("custom_components.inception.coordinator.ir.async_delete_issue"),
     ):
         # Create coordinator and set required attributes
         coordinator = InceptionUpdateCoordinator(mock_hass, mock_entry)
@@ -265,6 +269,7 @@ async def test_callbacks_reset_on_unload() -> None:
     mock_api.close = AsyncMock()
     mock_api.register_data_callback = Mock()
     mock_api.register_review_event_callback = Mock()
+    mock_api.register_auth_error_callback = Mock()
 
     # Create coordinator by mocking the parent class initialization
     with (
@@ -280,6 +285,8 @@ async def test_callbacks_reset_on_unload() -> None:
             "custom_components.inception.coordinator.async_get_clientsession",
             return_value=Mock(),
         ),
+        patch("custom_components.inception.coordinator.ir.async_create_issue"),
+        patch("custom_components.inception.coordinator.ir.async_delete_issue"),
     ):
         # Create coordinator and set required attributes
         coordinator = InceptionUpdateCoordinator(mock_hass, mock_entry)

--- a/tests/unit/test_coordinator_events.py
+++ b/tests/unit/test_coordinator_events.py
@@ -234,8 +234,6 @@ async def test_callbacks_registered_only_once() -> None:
             "custom_components.inception.coordinator.async_get_clientsession",
             return_value=Mock(),
         ),
-        patch("custom_components.inception.coordinator.ir.async_create_issue"),
-        patch("custom_components.inception.coordinator.ir.async_delete_issue"),
     ):
         # Create coordinator and set required attributes
         coordinator = InceptionUpdateCoordinator(mock_hass, mock_entry)
@@ -285,8 +283,6 @@ async def test_callbacks_reset_on_unload() -> None:
             "custom_components.inception.coordinator.async_get_clientsession",
             return_value=Mock(),
         ),
-        patch("custom_components.inception.coordinator.ir.async_create_issue"),
-        patch("custom_components.inception.coordinator.ir.async_delete_issue"),
     ):
         # Create coordinator and set required attributes
         coordinator = InceptionUpdateCoordinator(mock_hass, mock_entry)


### PR DESCRIPTION
## Summary

Previously, when the Inception controller rejected our API token (401/403), the background `_rest_task` logged the error and silently terminated. Entities went stale with no user-visible signal or remediation path.

This PR adopts Home Assistant's standard re-auth pattern:

- `_async_update_data` raises `ConfigEntryAuthFailed` on auth errors from the first data fetch, so HA flags the entry as needing re-auth and surfaces a "Reconfigure" prompt automatically.
- The background `_rest_task` auth-error callback now calls `config_entry.async_start_reauth(hass)` so failures detected outside the foreground update cycle also trigger the re-auth flow.
- The config flow gains `async_step_reauth` / `async_step_reauth_confirm` that prompt the user for a new API token, validate it against the existing host, and update the entry in place via `async_update_reload_and_abort`.
- Translations: new `reauth_confirm` step with guidance (check token under Users → Remote / Web Access → User API Token) and a `reauth_successful` abort message.

The API client side of the change remains: `register_auth_error_callback` is how both `_rest_task` and `_review_events_monitor` surface 401/403 back to the coordinator.

Implements Tier 1 #3 of the improvement analysis.

## Test plan
- [x] `tests/unit/test_auth_repairs.py` covers: callback deduplication, `_rest_task` fires callback on auth error, `_review_events_monitor` fires callback on auth error, `_trigger_reauth` delegates to `entry.async_start_reauth`, `_async_update_data` raises `ConfigEntryAuthFailed`, reauth callback is wired after a successful fetch
- [x] `scripts/lint` passes
- [x] `scripts/tests` passes locally (162/162)
- [x] Live smoke: revoke the API token on the controller and confirm HA shows a "Reconfigure" prompt on the Inception entry; enter a valid token and confirm the entry reloads cleanly