### PR TITLE
Bundle review events into the single /monitor-updates long-poll

### DIFF
--- a/custom_components/inception/pyinception/api.py
+++ b/custom_components/inception/pyinception/api.py
@@ -6,7 +6,6 @@ import asyncio
 import contextlib
 import logging
 import socket
-import time
 from typing import TYPE_CHECKING, Any, ClassVar, TypeVar
 from urllib.parse import urlencode
 
@@ -72,13 +71,9 @@ class InceptionApiClient:
         self.auth_error_cbs: list = []
         self.loop: asyncio.AbstractEventLoop = asyncio.get_running_loop()
         self.rest_task: asyncio.Task | None = None
-        self._review_events_task: asyncio.Task | None = None
         self._last_update: int | None = None
         self._review_events_enabled: bool = False
         self._review_events_categories: list[str] = []
-        self._last_review_log_time: float = 0
-        self._review_events_retry_count: int = 0
-        self._review_events_max_retry_delay: int = 300  # 5 minutes max
         self._rest_task_retry_count: int = 0
         self._rest_task_max_retry_delay: int = 300  # 5 minutes max
         self.protocol_version: int | None = None
@@ -170,8 +165,18 @@ class InceptionApiClient:
 
         return self.data
 
+    REVIEW_EVENTS_REQUEST_ID: ClassVar[str] = "LiveReviewEventsRequest"
+
     async def monitor_entity_states(self) -> None:
-        """Monitor updates from the API."""
+        """
+        Run a single long-poll iteration against `/monitor-updates`.
+
+        The payload bundles state-change sub-requests for all four entity
+        types (Input, Door, Output, Area), plus the LiveReviewEvents
+        sub-request when review events are enabled. The server returns a
+        response for exactly one sub-request per call (matched by `ID`),
+        so the dispatch here simply routes on the response `ID`.
+        """
         _LOGGER.debug("Starting long-poll monitor")
         if self.data is None:
             _LOGGER.warning("state monitor: no data to update")
@@ -195,8 +200,12 @@ class InceptionApiClient:
 
         payload = [
             request_type.get_request_payload()
-            for request_id, request_type in request_types.items()
+            for request_type in request_types.values()
         ]
+
+        review_request = await self._build_review_events_subrequest()
+        if review_request is not None:
+            payload.append(review_request.get_request_payload())
 
         response = await self._monitor_events_request(payload)
 
@@ -206,17 +215,33 @@ class InceptionApiClient:
 
         response_id = response["ID"]
 
+        if response_id == self.REVIEW_EVENTS_REQUEST_ID and self._review_events_enabled:
+            self._handle_review_events_response(response)
+            return
+
         update_request = request_types.get(response_id)
         if update_request is None:
             _LOGGER.error("Unknown response ID: %s", response_id)
             return
 
+        self._handle_entity_state_response(response, update_request)
+
+    def _handle_entity_state_response(
+        self,
+        response: dict[str, Any],
+        update_request: MonitorEntityStatesRequest,
+    ) -> None:
+        """Apply a MonitorEntityStates sub-request response to cached data."""
         result_response = UpdateMonitorResponse[update_request.public_state_type](
             **response["Result"]
         )
 
-        self._monitor_update_times[response_id] = result_response.update_time
+        self._monitor_update_times[update_request.request_id] = (
+            result_response.update_time
+        )
 
+        if self.data is None:
+            return
         entity_data: InceptionSummary = getattr(self.data, update_request.api_data)
         if entity_data is None:
             _LOGGER.error("No entity data for %s", update_request.api_data)
@@ -243,6 +268,48 @@ class InceptionApiClient:
             except Exception:
                 _LOGGER.exception("Error processing event")
 
+    def _handle_review_events_response(self, response: dict[str, Any]) -> None:
+        """Route a LiveReviewEvents sub-request response to the processor."""
+        result = response.get("Result", [])
+        if isinstance(result, list) and result:
+            self._process_review_events_data(result)
+
+    async def _build_review_events_subrequest(
+        self,
+    ) -> LiveReviewEventsRequest | None:
+        """
+        Construct the LiveReviewEvents sub-request payload if enabled.
+
+        On first use it establishes the reference point via
+        `_get_latest_review_event`; if that fails we skip adding the
+        sub-request this iteration rather than crashing the whole bundle.
+        """
+        if not self._review_events_enabled:
+            return None
+
+        if not self._review_events_reference_id:
+            latest = await self._get_latest_review_event()
+            if latest is None:
+                _LOGGER.warning(
+                    "Failed to establish review events reference point; "
+                    "skipping review events this iteration"
+                )
+                return None
+            InceptionApiClient._review_events_update_time = latest.get("WhenTicks", 0)
+            InceptionApiClient._review_events_reference_id = latest.get("ID")
+            _LOGGER.info(
+                "Established review events reference point: ID=%s, Time=%d",
+                self._review_events_reference_id,
+                self._review_events_update_time,
+            )
+
+        return LiveReviewEventsRequest(
+            request_id=self.REVIEW_EVENTS_REQUEST_ID,
+            reference_id=self._review_events_reference_id,
+            reference_time=self._review_events_update_time,
+            category_filter=self._review_events_categories or None,
+        )
+
     async def _get_latest_review_event(self) -> dict[str, Any] | None:
         """Get the latest review event to establish reference point."""
         try:
@@ -266,63 +333,6 @@ class InceptionApiClient:
         except Exception:
             _LOGGER.exception("Error getting latest review event")
             return None
-
-    async def monitor_review_events(self, categories: list[str] | None = None) -> None:
-        """Monitor review events from the API using long polling."""
-        try:
-            # If we don't have a reference point, get the latest event first
-            if (
-                self._review_events_update_time == 0
-                or not self._review_events_reference_id
-            ):
-                latest_event = await self._get_latest_review_event()
-                if latest_event:
-                    InceptionApiClient._review_events_update_time = latest_event.get(
-                        "WhenTicks", 0
-                    )
-                    InceptionApiClient._review_events_reference_id = latest_event.get(
-                        "ID"
-                    )
-                    _LOGGER.info(
-                        "Established review events reference point: ID=%s, Time=%d",
-                        self._review_events_reference_id,
-                        self._review_events_update_time,
-                    )
-                else:
-                    _LOGGER.warning("Failed to establish review events reference point")
-                    return
-
-            # Create the live review events request
-            # Ensure we have a valid reference_id (should never be None at this point)
-            if not self._review_events_reference_id:
-                _LOGGER.error("No reference ID available for live review events")
-                return
-
-            request = LiveReviewEventsRequest(
-                request_id="LiveReviewEventsRequest",
-                reference_id=self._review_events_reference_id,
-                reference_time=self._review_events_update_time,
-                category_filter=categories,
-            )
-
-            payload = [request.get_request_payload()]
-            response = await self._monitor_events_request(payload)
-
-            if not response:
-                return
-
-            result = response.get("Result", [])
-            if len(result) > 0:
-                self._process_review_events_data(result)
-
-        except (
-            InceptionApiClientAuthenticationError,
-            InceptionApiClientCommunicationError,
-        ):
-            # Let these errors propagate to _review_events_task for proper handling
-            raise
-        except Exception:
-            _LOGGER.exception("Error monitoring review events")
 
     def _process_review_events_data(self, events_data: Any) -> None:
         """Process review events data and trigger callbacks."""
@@ -431,53 +441,6 @@ class InceptionApiClient:
                 await asyncio.sleep(delay)
             self._schedule_data_callbacks()
 
-    async def _review_events_monitor(self) -> None:
-        """Monitor review events using long polling while enabled."""
-        _LOGGER.debug("Review events task started with long polling")
-
-        try:
-            while self._review_events_enabled:
-                try:
-                    # Only log debug message every 60 seconds to reduce spam
-                    current_time = time.time()
-                    if current_time - self._last_review_log_time > 60:
-                        _LOGGER.debug(
-                            "Review events monitoring categories: %s",
-                            self._review_events_categories,
-                        )
-                        self._last_review_log_time = current_time
-
-                    await self.monitor_review_events(self._review_events_categories)
-                    # Reset retry count on successful monitoring
-                    self._reset_retry_count("review_events")
-                    # No sleep needed - long polling will wait for events
-                except InceptionApiClientAuthenticationError:
-                    # Authentication errors always stop the task
-                    self._schedule_auth_error_callbacks()
-                    raise
-                except InceptionApiClientCommunicationError as e:
-                    # Check if it's a 4xx client error (irrecoverable)
-                    if (
-                        "404" in str(e)
-                        or "400" in str(e)
-                        or "403" in str(e)
-                        or "401" in str(e)
-                    ):
-                        # 4xx errors stop the task
-                        raise
-                    # For 5xx errors (network issues), use exponential backoff
-                    _LOGGER.warning("Communication error in review events: %s", e)
-                    delay = self._increment_retry_count("review_events")
-                    await asyncio.sleep(delay)
-                except Exception:
-                    _LOGGER.exception("Unexpected error in review events task")
-                    # For unexpected errors, use exponential backoff
-                    delay = self._increment_retry_count("review_events")
-                    await asyncio.sleep(delay)
-
-        finally:
-            _LOGGER.debug("Review events task stopped")
-
     @staticmethod
     def _get_retry_delay(retry_count: int, max_delay: int = 300) -> int:
         """Calculate exponential backoff delay for retries."""
@@ -516,10 +479,11 @@ class InceptionApiClient:
         """Close the session."""
         _LOGGER.debug("Closing session")
 
-        # Stop review events task
-        await self.stop_review_listener()
+        # Disable review-event bundling so a partial restart doesn't inherit it.
+        self._review_events_enabled = False
+        self._review_events_categories = []
 
-        # Stop main rest task
+        # Stop main rest task (which owns the single long-poll connection).
         if self.rest_task:
             if not self.rest_task.cancelled():
                 self.rest_task.cancel()
@@ -529,10 +493,10 @@ class InceptionApiClient:
         # Clear callback lists to prevent memory leaks
         self.data_update_cbs.clear()
         self.review_event_cbs.clear()
+        self.auth_error_cbs.clear()
 
         # Reset task references
         self.rest_task = None
-        self._review_events_task = None
 
     async def _monitor_events_request(self, payload: Any) -> Any | None:
         """Monitor updates from the API."""
@@ -649,39 +613,28 @@ class InceptionApiClient:
         return await self._control_item(item=f"input/{input_id}", data=data)
 
     async def start_review_listener(self, categories: list[str]) -> None:
-        """Start the review event listener with specific categories."""
+        """
+        Enable bundled review-event polling on the next long-poll iteration.
+
+        No separate task is spawned: the main `_rest_task` long-poll picks
+        up the flag on its next iteration and adds a LiveReviewEvents
+        sub-request to the same HTTP request.
+        """
         _LOGGER.debug(
-            "Starting review events listener for categories: %s (was enabled: %s)",
+            "Enabling review events listener for categories: %s (was enabled: %s)",
             categories,
             self._review_events_enabled,
         )
-
-        # Stop existing task if running
-        await self.stop_review_listener()
-
-        # Start new task
         self._review_events_enabled = True
         self._review_events_categories = categories[:]
-        self._review_events_retry_count = 0  # Reset retry count on start
-        self._review_events_task = asyncio.create_task(self._review_events_monitor())
-        _LOGGER.info("Review events listener started for categories: %s", categories)
+        _LOGGER.info("Review events listener enabled for categories: %s", categories)
 
     async def stop_review_listener(self) -> None:
-        """Stop the review event listener."""
+        """Disable bundled review-event polling from the next iteration."""
         _LOGGER.debug(
-            "Stopping review events listener (was enabled: %s)",
+            "Disabling review events listener (was enabled: %s)",
             self._review_events_enabled,
         )
-
-        # Set disabled first to stop the loop
         self._review_events_enabled = False
         self._review_events_categories = []
-
-        # Cancel and wait for the task to finish
-        if self._review_events_task and not self._review_events_task.done():
-            self._review_events_task.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await self._review_events_task
-
-        self._review_events_task = None
-        _LOGGER.info("Review events listener stopped")
+        _LOGGER.info("Review events listener disabled")

--- a/custom_components/inception/pyinception/schemas/review_events.py
+++ b/custom_components/inception/pyinception/schemas/review_events.py
@@ -45,6 +45,7 @@ class LiveReviewEventsRequest:
             input_data["messageTypeIdFilter"] = self.message_type_id_filter
 
         return {
+            "ID": self.request_id,
             "RequestType": "LiveReviewEvents",
             "InputData": input_data,
         }

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -171,6 +171,7 @@ async def test_api_client_close_clears_callbacks() -> None:
     assert len(api_client.data_update_cbs) == 0
     assert len(api_client.review_event_cbs) == 0
 
-    # Verify task references were reset
+    # Verify task references were reset; the separate review-events task no
+    # longer exists as review events are bundled into the main long-poll.
     assert api_client.rest_task is None
-    assert api_client._review_events_task is None
+    assert not hasattr(api_client, "_review_events_task")

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any
 from unittest.mock import Mock, patch
 
@@ -34,8 +35,12 @@ class TestInceptionApiClient:
 
     def test_review_events_methods_exist(self) -> None:
         """Test that review events methods exist on API client."""
-        # Test that review events methods exist
-        assert hasattr(InceptionApiClient, "monitor_review_events")
+        # Review events are now bundled into the main /monitor-updates
+        # long-poll. The helpers that remain are:
+        assert hasattr(InceptionApiClient, "start_review_listener")
+        assert hasattr(InceptionApiClient, "stop_review_listener")
+        assert hasattr(InceptionApiClient, "_build_review_events_subrequest")
+        assert hasattr(InceptionApiClient, "_process_review_events_data")
         assert hasattr(InceptionApiClient, "_review_events_request")
 
     def test_review_events_class_variable_exists(self) -> None:
@@ -60,172 +65,12 @@ class TestInceptionApiClient:
         assert str(comm_error) == "test"
 
 
-class TestReviewEventsPermissions:
-    """Test review events permission handling."""
-
-    @pytest.fixture
-    def mock_session(self) -> Mock:
-        """Create a mock session."""
-        return Mock(spec=aiohttp.ClientSession)
+class TestRetryBackoffDelay:
+    """Static retry-delay helper used by _rest_task's backoff."""
 
     @pytest.mark.asyncio
-    async def test_review_events_404_logs_warning_and_stops_retries(
-        self, mock_session: Mock, caplog: pytest.LogCaptureFixture
-    ) -> None:
-        """Test that 404 on review endpoint logs warning and stops retries."""
-        # Create API client within the test
-        api_client = InceptionApiClient(
-            token="test_token",
-            host="http://test.com",
-            session=mock_session,
-        )
-
-        # Enable review events for testing
-        api_client._review_events_enabled = True
-        api_client._review_events_categories = ["System"]
-
-        # Mock the monitor_review_events method to raise a 404 error
-        with patch.object(api_client, "monitor_review_events") as mock_monitor:
-            # Simulate a 404 response by raising a communication error with 404
-            mock_monitor.side_effect = InceptionApiClientCommunicationError(
-                "Error fetching information - 404, message='Not Found', url='http://test.com/api/v1/review'"
-            )
-
-            # Start the review events task - it should exit after raising the error
-            with pytest.raises(InceptionApiClientCommunicationError) as exc_info:
-                await api_client._review_events_monitor()
-
-            # Verify the 404 error was raised
-            assert "404" in str(exc_info.value)
-
-            # Verify task started and stopped correctly
-            log_messages = [record.message for record in caplog.records]
-            assert any("Review events task started" in msg for msg in log_messages)
-            assert any("Review events task stopped" in msg for msg in log_messages)
-
-    @pytest.mark.asyncio
-    async def test_review_events_403_logs_warning_and_stops_retries(
-        self, mock_session: Mock, caplog: pytest.LogCaptureFixture
-    ) -> None:
-        """Test that 403 on review endpoint logs warning and stops retries."""
-        # Create API client within the test
-        api_client = InceptionApiClient(
-            token="test_token",
-            host="http://test.com",
-            session=mock_session,
-        )
-
-        # Enable review events for testing
-        api_client._review_events_enabled = True
-        api_client._review_events_categories = ["System"]
-
-        # Mock the monitor_review_events method to raise a 403 error
-        with patch.object(api_client, "monitor_review_events") as mock_monitor:
-            # Simulate a 403 response
-            mock_monitor.side_effect = InceptionApiClientCommunicationError(
-                "Error fetching information - 403, message='Forbidden', url='http://test.com/api/v1/review'"
-            )
-
-            # Start the review events task - it should exit after raising the error
-            with pytest.raises(InceptionApiClientCommunicationError) as exc_info:
-                await api_client._review_events_monitor()
-
-            # Verify the 403 error was raised
-            assert "403" in str(exc_info.value)
-
-            # Verify task started and stopped correctly
-            log_messages = [record.message for record in caplog.records]
-            assert any("Review events task started" in msg for msg in log_messages)
-            assert any("Review events task stopped" in msg for msg in log_messages)
-
-    @pytest.mark.asyncio
-    async def test_review_events_auth_error_stops_retries(
-        self, mock_session: Mock, caplog: pytest.LogCaptureFixture
-    ) -> None:
-        """Test that authentication errors stop retries."""
-        # Create API client within the test
-        api_client = InceptionApiClient(
-            token="test_token",
-            host="http://test.com",
-            session=mock_session,
-        )
-
-        # Enable review events for testing
-        api_client._review_events_enabled = True
-        api_client._review_events_categories = ["System"]
-
-        # Mock the monitor_review_events method to raise an authentication error
-        with patch.object(api_client, "monitor_review_events") as mock_monitor:
-            mock_monitor.side_effect = InceptionApiClientAuthenticationError(
-                "Invalid credentials"
-            )
-
-            # Start the review events task - it should exit after raising the error
-            with pytest.raises(InceptionApiClientAuthenticationError):
-                await api_client._review_events_monitor()
-
-            # Verify task started and stopped correctly
-            log_messages = [record.message for record in caplog.records]
-            assert any("Review events task started" in msg for msg in log_messages)
-            assert any("Review events task stopped" in msg for msg in log_messages)
-
-    @pytest.mark.asyncio
-    async def test_review_events_network_error_retries(
-        self, mock_session: Mock, caplog: pytest.LogCaptureFixture
-    ) -> None:
-        """Test that network errors are retried."""
-        # Create API client within the test
-        api_client = InceptionApiClient(
-            token="test_token",
-            host="http://test.com",
-            session=mock_session,
-        )
-
-        # Enable review events for testing
-        api_client._review_events_enabled = True
-        api_client._review_events_categories = ["System"]
-
-        # Mock the monitor_review_events method to raise a network error (5xx)
-        call_count = 0
-
-        def side_effect(categories: list[str] | None = None) -> None:
-            nonlocal call_count
-            call_count += 1
-            # Verify categories are passed correctly
-            assert categories == ["System"]
-            if call_count == 1:
-                # First call raises error
-                error_msg = (
-                    "Error fetching information - 500, message='Internal Server Error'"
-                )
-                raise InceptionApiClientCommunicationError(error_msg)
-            # Second call would succeed, but we'll cancel before then
-
-        with patch.object(api_client, "monitor_review_events", side_effect=side_effect):
-            # Start the review events task, let it run once to see retry behavior
-            task = asyncio.create_task(api_client._review_events_monitor())
-
-            # Let it run briefly to process the first error and start waiting
-            await asyncio.sleep(0.1)
-            task.cancel()
-
-            with contextlib.suppress(asyncio.CancelledError):
-                await task
-
-            # Verify that the communication error was logged and retry scheduled
-            log_messages = [record.message for record in caplog.records]
-            assert any(
-                "Communication error in review events:" in msg for msg in log_messages
-            ), f"Expected communication error not found in: {log_messages}"
-            assert any(
-                "review_events: error #1, retrying in 5 seconds" in msg
-                for msg in log_messages
-            ), f"Expected retry backoff message not found in: {log_messages}"
-
-    @pytest.mark.asyncio
-    async def test_review_events_exponential_backoff(self) -> None:
-        """Test that exponential backoff works correctly for retries."""
-        # Test the backoff calculation directly via the static method
+    async def test_exponential_backoff(self) -> None:
+        """The exponential backoff ladder is capped at 5 minutes."""
         assert InceptionApiClient._get_retry_delay(0) == 5  # First retry
         assert InceptionApiClient._get_retry_delay(1) == 5  # 5 * 2^0 = 5
         assert InceptionApiClient._get_retry_delay(2) == 10  # 5 * 2^1 = 10
@@ -263,41 +108,53 @@ class TestReviewEventCallbacks:
 
     @pytest.mark.asyncio
     async def test_review_event_callback_triggered(self, mock_session: Mock) -> None:
-        """Test that review event callbacks are triggered when events are processed."""
+        """A bundled review-events response routes events to registered callbacks."""
         api_client = InceptionApiClient(
             token="test_token",
             host="http://test.com",
             session=mock_session,
         )
 
-        # Mock the _review_events_request to return sample event data
-        mock_event_data = [
-            {
-                "ID": "event123",
-                "MessageType": "DoorAccess",
-                "Description": "Card access granted",
-                "MessageCategory": "Access",
-                "When": "2023-12-01T10:30:00Z",
-                "Who": "John Doe",
-                "What": "Door 1",
-                "Where": "Main Entrance",
-                "WhenTicks": 1701432600,
-                "MessageID": 5001,
-            }
-        ]
+        # Pretend the reference point has been established; otherwise
+        # _process_review_events_data treats the batch as initial load
+        # and suppresses callbacks.
+        InceptionApiClient._review_events_update_time = 1_000_000_000
+        InceptionApiClient._review_events_reference_id = "prior-event"
 
         callback = Mock()
         api_client.register_review_event_callback(callback)
 
-        with patch.object(
-            api_client, "_review_events_request", return_value=mock_event_data
-        ):
-            await api_client.monitor_review_events()
+        bundled_response = {
+            "ID": InceptionApiClient.REVIEW_EVENTS_REQUEST_ID,
+            "Result": [
+                {
+                    "ID": "event123",
+                    "MessageType": "DoorAccess",
+                    "Description": "Card access granted",
+                    "MessageCategory": "Access",
+                    "When": "2023-12-01T10:30:00Z",
+                    "Who": "John Doe",
+                    "What": "Door 1",
+                    "Where": "Main Entrance",
+                    "WhenTicks": 2_000_000_000,
+                    "MessageID": 5001,
+                }
+            ],
+        }
 
-        # Verify the callback was scheduled to be called
-        # Since we're using call_soon_threadsafe, callback not called yet
-        assert callback.call_count == 0  # Not called yet due to threading
-        assert len(api_client.review_event_cbs) == 1
+        scheduled: list[tuple[Mock, dict]] = []
+        api_client.loop = SimpleNamespace(
+            call_soon_threadsafe=lambda cb, event: scheduled.append((cb, event))
+        )
+
+        api_client._handle_review_events_response(bundled_response)
+
+        assert len(scheduled) == 1
+        assert scheduled[0][0] is callback
+        assert scheduled[0][1]["ID"] == "event123"
+        # The reference-time update happens in-process (not deferred).
+        assert InceptionApiClient._review_events_update_time == 2_000_000_000
+        assert InceptionApiClient._review_events_reference_id == "event123"
 
     @pytest.mark.asyncio
     async def test_multiple_review_event_callbacks(self, mock_session: Mock) -> None:
@@ -745,3 +602,182 @@ class TestRequestApiPrefix:
 
         called_url = mock_session.request.call_args.kwargs["url"]
         assert called_url == "http://h.test/api/v1/control/input"
+
+
+class TestBundledLongPoll:
+    """The single long-poll now bundles entity-state AND review-event requests."""
+
+    @pytest.fixture
+    def mock_session(self) -> Mock:
+        """Return a mocked aiohttp session."""
+        return Mock(spec=aiohttp.ClientSession)
+
+    def setup_method(self) -> None:
+        """Reset shared class state between tests."""
+        InceptionApiClient._review_events_update_time = 0
+        InceptionApiClient._review_events_reference_id = None
+        InceptionApiClient._monitor_update_times = {}
+
+    @pytest.mark.asyncio
+    async def test_payload_excludes_review_request_when_disabled(
+        self, mock_session: Mock
+    ) -> None:
+        """With review events disabled, only the 4 entity sub-requests are sent."""
+        api_client = InceptionApiClient(
+            token="t", host="http://h.test", session=mock_session
+        )
+        api_client.data = Mock()
+        api_client._review_events_enabled = False
+
+        captured_payloads: list[list[dict[str, Any]]] = []
+
+        async def fake_request(payload: list[dict[str, Any]]) -> None:
+            captured_payloads.append(payload)
+
+        with patch.object(
+            api_client, "_monitor_events_request", side_effect=fake_request
+        ):
+            await api_client.monitor_entity_states()
+
+        assert len(captured_payloads) == 1
+        ids = [entry["ID"] for entry in captured_payloads[0]]
+        assert ids == [
+            "InputStateRequest",
+            "DoorStateRequest",
+            "OutputStateRequest",
+            "AreaStateRequest",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_payload_includes_review_request_when_enabled(
+        self, mock_session: Mock
+    ) -> None:
+        """With review events enabled, a 5th LiveReviewEvents sub-request is added."""
+        api_client = InceptionApiClient(
+            token="t", host="http://h.test", session=mock_session
+        )
+        api_client.data = Mock()
+        api_client._review_events_enabled = True
+        api_client._review_events_categories = ["Access", "Security"]
+
+        # Pretend reference point is already set so we don't hit the API.
+        InceptionApiClient._review_events_reference_id = "prior-event"
+        InceptionApiClient._review_events_update_time = 123
+
+        captured_payloads: list[list[dict[str, Any]]] = []
+
+        async def fake_request(payload: list[dict[str, Any]]) -> None:
+            captured_payloads.append(payload)
+
+        with patch.object(
+            api_client, "_monitor_events_request", side_effect=fake_request
+        ):
+            await api_client.monitor_entity_states()
+
+        assert len(captured_payloads) == 1
+        ids = [entry["ID"] for entry in captured_payloads[0]]
+        assert InceptionApiClient.REVIEW_EVENTS_REQUEST_ID in ids
+        assert len(ids) == 5
+
+    @pytest.mark.asyncio
+    async def test_review_events_response_routed_to_processor(
+        self, mock_session: Mock
+    ) -> None:
+        """A response tagged with the review events ID routes to events handling."""
+        api_client = InceptionApiClient(
+            token="t", host="http://h.test", session=mock_session
+        )
+        api_client.data = Mock()
+        api_client._review_events_enabled = True
+        api_client._review_events_categories = ["Access"]
+        InceptionApiClient._review_events_reference_id = "prior"
+        InceptionApiClient._review_events_update_time = 1_000_000_000
+
+        review_response = {
+            "ID": InceptionApiClient.REVIEW_EVENTS_REQUEST_ID,
+            "Result": [
+                {
+                    "ID": "new-event",
+                    "Description": "Door access granted",
+                    "WhenTicks": 2_000_000_000,
+                }
+            ],
+        }
+
+        with (
+            patch.object(
+                api_client, "_monitor_events_request", return_value=review_response
+            ),
+            patch.object(
+                api_client, "_handle_review_events_response"
+            ) as mock_review_handler,
+            patch.object(
+                api_client, "_handle_entity_state_response"
+            ) as mock_entity_handler,
+        ):
+            await api_client.monitor_entity_states()
+
+        mock_review_handler.assert_called_once_with(review_response)
+        mock_entity_handler.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_entity_state_response_routed_to_entity_handler(
+        self, mock_session: Mock
+    ) -> None:
+        """A response tagged with an entity ID routes to entity-state handling."""
+        api_client = InceptionApiClient(
+            token="t", host="http://h.test", session=mock_session
+        )
+        api_client.data = Mock()
+        api_client._review_events_enabled = False
+
+        state_response = {
+            "ID": "DoorStateRequest",
+            "Result": {"updateTime": "1", "stateData": []},
+        }
+
+        with (
+            patch.object(
+                api_client, "_monitor_events_request", return_value=state_response
+            ),
+            patch.object(
+                api_client, "_handle_entity_state_response"
+            ) as mock_entity_handler,
+            patch.object(
+                api_client, "_handle_review_events_response"
+            ) as mock_review_handler,
+        ):
+            await api_client.monitor_entity_states()
+
+        mock_entity_handler.assert_called_once()
+        mock_review_handler.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_start_review_listener_flips_flag_without_task(
+        self, mock_session: Mock
+    ) -> None:
+        """start_review_listener just enables bundling; no task is spawned."""
+        api_client = InceptionApiClient(
+            token="t", host="http://h.test", session=mock_session
+        )
+
+        await api_client.start_review_listener(["Access", "Security"])
+
+        assert api_client._review_events_enabled is True
+        assert api_client._review_events_categories == ["Access", "Security"]
+        # No separate task should exist.
+        assert not hasattr(api_client, "_review_events_task")
+
+    @pytest.mark.asyncio
+    async def test_stop_review_listener_clears_flag(self, mock_session: Mock) -> None:
+        """stop_review_listener disables bundling and clears categories."""
+        api_client = InceptionApiClient(
+            token="t", host="http://h.test", session=mock_session
+        )
+        api_client._review_events_enabled = True
+        api_client._review_events_categories = ["Access"]
+
+        await api_client.stop_review_listener()
+
+        assert api_client._review_events_enabled is False
+        assert api_client._review_events_categories == []

--- a/tests/unit/test_auth_repairs.py
+++ b/tests/unit/test_auth_repairs.py
@@ -66,36 +66,6 @@ class TestAuthErrorCallback:
 
         assert cb in scheduled
 
-    @pytest.mark.asyncio
-    async def test_review_events_fires_auth_callback_on_auth_error(
-        self, mock_session: Mock
-    ) -> None:
-        """Auth errors bubbling out of _review_events_monitor also fire cbs."""
-        client = InceptionApiClient(
-            token="t", host="http://h.test", session=mock_session
-        )
-        scheduled: list[object] = []
-        client.loop = SimpleNamespace(
-            call_soon_threadsafe=lambda cb, *_: scheduled.append(cb)
-        )
-        client._review_events_enabled = True
-        client._review_events_categories = ["System"]
-
-        cb = Mock()
-        client.register_auth_error_callback(cb)
-
-        async def raise_auth_error(_categories: list[str] | None = None) -> None:
-            msg = "Invalid credentials"
-            raise InceptionApiClientAuthenticationError(msg)
-
-        with (
-            patch.object(client, "monitor_review_events", side_effect=raise_auth_error),
-            pytest.raises(InceptionApiClientAuthenticationError),
-        ):
-            await client._review_events_monitor()
-
-        assert cb in scheduled
-
 
 class TestRequestPreservesAuthErrorType:
     """`request()` must not rewrap our auth errors as generic errors."""

--- a/tests/unit/test_review_events.py
+++ b/tests/unit/test_review_events.py
@@ -48,6 +48,7 @@ class TestLiveReviewEventsRequest:
         payload = request.get_request_payload()
 
         expected_payload = {
+            "ID": "LiveReviewEventsRequest",
             "RequestType": "LiveReviewEvents",
             "InputData": {
                 "referenceId": "ref123",
@@ -68,6 +69,7 @@ class TestLiveReviewEventsRequest:
         payload = request.get_request_payload()
 
         expected_payload = {
+            "ID": "LiveReviewEventsRequest",
             "RequestType": "LiveReviewEvents",
             "InputData": {
                 "referenceId": "ref456",


### PR DESCRIPTION
## Summary

Previously the client ran two parallel background tasks:
- `_rest_task` long-polling the entity-state sub-requests
- `_review_events_monitor` long-polling `LiveReviewEvents`

That meant two HTTP sockets per controller, two retry ladders, and two places that had to handle auth failure. The Inner Range docs explicitly recommend bundling sub-requests into one request (see \`docs/inception-api/long-polling.md\` — \"Example: Monitoring both Area states and Output states\"), and the server already dispatches responses by sub-request \`ID\`.

This PR collapses both loops into one:
- `monitor_entity_states()` builds a payload with the 4 entity sub-requests plus — when review events are enabled — a `LiveReviewEvents` sub-request, then dispatches the response by `ID` to either `_handle_entity_state_response` or `_handle_review_events_response`.
- `start_review_listener` / `stop_review_listener` are now just flag setters — no separate task to spawn or cancel.
- `close()` no longer needs to tear down a second task.

### Drive-by fix

`LiveReviewEventsRequest.get_request_payload()` did not include the `ID` field. This worked by accident when it was the only sub-request in the body but would have been ambiguous with multiple bundled sub-requests. The field is now set from `request_id` (matching `MonitorEntityStatesRequest`).

Implements Tier 1 #1 of the improvement analysis.

## Test plan
- [x] New `TestBundledLongPoll` class in `tests/unit/test_api.py`: payload shape with/without review events enabled, response dispatch by `ID` to entity vs review handlers, `start_review_listener` enables bundling without spawning a task, `stop_review_listener` clears flags
- [x] Existing `TestReviewEventCallbacks::test_review_event_callback_triggered` rewritten against the new `_handle_review_events_response` entry point
- [x] Existing `TestReviewEventsInitialLoad` tests continue to pass (they exercise `_process_review_events_data` directly, which is unchanged)
- [x] Obsolete `TestReviewEventsPermissions` tests for the removed `_review_events_monitor` task retry paths removed; `_rest_task` backoff already covered by `TestRestTaskBackoff`
- [x] `test_review_events.py` schema payload expectations updated to include the `ID` field
- [x] `scripts/lint` passes
- [x] `scripts/tests` passes locally (158/158)
- [x] Live smoke: enable the review-events switch against a real controller and confirm events fire + entity states still stream