### PR TITLE
Fix duplicate-unique-id error on last-review-event sensor

### DIFF
--- a/custom_components/inception/coordinator.py
+++ b/custom_components/inception/coordinator.py
@@ -8,7 +8,6 @@ from homeassistant.const import CONF_HOST, CONF_TOKEN, EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import callback
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from homeassistant.helpers.entity_registry import RegistryEntryDisabler, async_get
 from homeassistant.helpers.storage import Store
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
@@ -265,29 +264,6 @@ class InceptionUpdateCoordinator(DataUpdateCoordinator[InceptionApiData]):
         """Set the review events global enabled state and notify entities."""
         if self._review_events_global_enabled != value:
             self._review_events_global_enabled = value
-            # Force update to notify sensor entities of state change
+            # Notify CoordinatorEntity subscribers (e.g. the last-review-event
+            # sensor uses this to flip its `available` state).
             self.async_update_listeners()
-            # Update sensor entity enabled state
-            self.hass.async_create_task(self._update_sensor_enabled_state())
-
-    async def _update_sensor_enabled_state(self) -> None:
-        """Update sensor entity enabled state based on review events setting."""
-        entity_registry = async_get(self.hass)
-        # Construct the sensor entity ID based on the unique ID pattern
-        sensor_unique_id = f"{self.config_entry.entry_id}_last_review_event"
-        # Find the entity by unique ID rather than guessing entity ID
-        for entity_id, entity_entry in entity_registry.entities.items():
-            if entity_entry.unique_id == sensor_unique_id:
-                should_be_enabled = self._review_events_global_enabled
-                if entity_entry.disabled_by is None and not should_be_enabled:
-                    # Disable the entity
-                    entity_registry.async_update_entity(
-                        entity_id, disabled_by=RegistryEntryDisabler.INTEGRATION
-                    )
-                elif (
-                    entity_entry.disabled_by == RegistryEntryDisabler.INTEGRATION
-                    and should_be_enabled
-                ):
-                    # Enable the entity
-                    entity_registry.async_update_entity(entity_id, disabled_by=None)
-                break

--- a/custom_components/inception/sensor.py
+++ b/custom_components/inception/sensor.py
@@ -10,7 +10,6 @@ from homeassistant.components.sensor import (
 )
 from homeassistant.const import EntityCategory
 from homeassistant.core import callback
-from homeassistant.helpers.entity_registry import RegistryEntryDisabler, async_get
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN, EVENT_REVIEW_EVENT
@@ -68,102 +67,39 @@ class InceptionLastReviewEventSensor(
         self._event_listener_remove: Callable[[], None] | None = None
 
     async def async_added_to_hass(self) -> None:
-        """Run when entity is added to Home Assistant."""
+        """Subscribe to review events when the entity is added to HA."""
         await super().async_added_to_hass()
-
-        # Start event listener
-        self._start_event_listener()
-
-        # Update enabled state based on current switch state
-        await self._update_entity_enabled_state()
-
-        # Listen for entity registry updates to handle manual enable/disable
-        self.async_on_remove(
-            self.hass.bus.async_listen(
-                "entity_registry_updated",
-                self._handle_entity_registry_update,
-            )
+        self._event_listener_remove = self.hass.bus.async_listen(
+            EVENT_REVIEW_EVENT,
+            self._handle_review_event,
         )
 
     async def async_will_remove_from_hass(self) -> None:
-        """Run when entity will be removed from Home Assistant."""
-        # Clean up event listener
-        self._stop_event_listener()
-
-        await super().async_will_remove_from_hass()
-
-    async def _update_entity_enabled_state(self) -> None:
-        """Update the entity's enabled state based on review events switch."""
-        coordinator = cast("InceptionUpdateCoordinator", self.coordinator)
-        entity_registry = async_get(self.hass)
-
-        if entity_entry := entity_registry.async_get(self.entity_id):
-            should_be_enabled = coordinator.review_events_global_enabled
-            if entity_entry.disabled_by is None and not should_be_enabled:
-                # Stop the event listener before disabling
-                self._stop_event_listener()
-                # Disable the entity
-                entity_registry.async_update_entity(
-                    self.entity_id, disabled_by=RegistryEntryDisabler.INTEGRATION
-                )
-            elif (
-                entity_entry.disabled_by == RegistryEntryDisabler.INTEGRATION
-                and should_be_enabled
-            ):
-                # Enable the entity
-                entity_registry.async_update_entity(self.entity_id, disabled_by=None)
-                # Start the event listener after enabling
-                self._start_event_listener()
-
-    def _start_event_listener(self) -> None:
-        """Start the event listener if not already running and entity is enabled."""
-        if (
-            self._event_listener_remove is None
-            and self.hass is not None
-            and self._is_entity_enabled()
-        ):
-            self._event_listener_remove = self.hass.bus.async_listen(
-                EVENT_REVIEW_EVENT,
-                self._handle_review_event,
-            )
-
-    def _stop_event_listener(self) -> None:
-        """Stop the event listener if running."""
+        """Unsubscribe from review events when the entity is removed."""
         if self._event_listener_remove is not None:
             self._event_listener_remove()
             self._event_listener_remove = None
-
-    def _is_entity_enabled(self) -> bool:
-        """Check if the entity is currently enabled."""
-        if self.entity_id is None or self.hass is None:
-            return False
-
-        entity_registry = async_get(self.hass)
-        if entity_entry := entity_registry.async_get(self.entity_id):
-            return entity_entry.disabled_by is None
-        return True  # If not in registry yet, assume enabled
-
-    @callback
-    def _handle_entity_registry_update(self, event: Any) -> None:
-        """Handle entity registry updates to manage event listener state."""
-        # Check if this update is for our entity and disabled_by changed
-        if (
-            event.data.get("action") == "update"
-            and event.data.get("entity_id") == self.entity_id
-            and "disabled_by" in event.data.get("changes", {})
-        ):
-            if self._is_entity_enabled():
-                # Entity was enabled, start listener
-                self._start_event_listener()
-            else:
-                # Entity was disabled, stop listener
-                self._stop_event_listener()
+        await super().async_will_remove_from_hass()
 
     @callback
     def _handle_review_event(self, event: Any) -> None:
         """Handle incoming review events."""
         self._last_event_data = event.data
         self.async_write_ha_state()
+
+    @property
+    def available(self) -> bool:
+        """
+        Reflect the global review-events switch.
+
+        We previously toggled `disabled_by` on the registry entry to hide the
+        sensor when review events were off, but that re-added the entity to
+        the platform and triggered a "duplicate unique IDs" error. Using
+        `available` is the idiomatic HA pattern for "exists, but no data
+        right now" and avoids touching the registry at runtime.
+        """
+        coordinator = cast("InceptionUpdateCoordinator", self.coordinator)
+        return coordinator.review_events_global_enabled
 
     @property
     def native_value(self) -> str | None:
@@ -192,12 +128,6 @@ class InceptionLastReviewEventSensor(
             "where": self._last_event_data.get("where"),
             "where_id": self._last_event_data.get("where_id"),
         }
-
-    @property
-    def entity_registry_enabled_default(self) -> bool:
-        """Return if entity should be enabled when first added to registry."""
-        coordinator = cast("InceptionUpdateCoordinator", self.coordinator)
-        return coordinator.review_events_global_enabled
 
     @property
     def device_info(self) -> dict[str, Any]:

--- a/tests/unit/test_sensor.py
+++ b/tests/unit/test_sensor.py
@@ -59,19 +59,19 @@ class TestInceptionLastReviewEventSensor:
         assert sensor.native_value is None
         assert sensor.extra_state_attributes is None
 
-    def test_entity_registry_enabled_default_when_disabled(
+    def test_available_when_review_events_disabled(
         self, sensor: InceptionLastReviewEventSensor, mock_coordinator: Mock
     ) -> None:
-        """Test sensor registry enabled default when review events are disabled."""
+        """Sensor should report unavailable when the global switch is off."""
         mock_coordinator.review_events_global_enabled = False
-        assert not sensor.entity_registry_enabled_default
+        assert sensor.available is False
 
-    def test_entity_registry_enabled_default_when_enabled(
+    def test_available_when_review_events_enabled(
         self, sensor: InceptionLastReviewEventSensor, mock_coordinator: Mock
     ) -> None:
-        """Test sensor registry enabled default when review events are enabled."""
+        """Sensor should report available when the global switch is on."""
         mock_coordinator.review_events_global_enabled = True
-        assert sensor.entity_registry_enabled_default
+        assert sensor.available is True
 
     def test_handle_review_event(self, sensor: InceptionLastReviewEventSensor) -> None:
         """Test handling a review event."""


### PR DESCRIPTION
## Summary

Fixes the recurring `Platform inception does not generate unique IDs. ID …_last_review_event already exists - ignoring sensor.…_last_review_event` error that fires whenever the global review-events switch is toggled.

## Root cause

When the integration loaded with the global review-events switch already enabled, this sequence ran:

1. `sensor.async_setup_entry` registered the sensor with `entity_registry_enabled_default=False` (the coordinator's initial value of `_review_events_global_enabled` is `False`), so the sensor was tracked by the platform as a disabled entity.
2. Moments later, `ReviewEventGlobalSwitch.async_added_to_hass` loaded the stored state (`True`) and assigned it to `coordinator.review_events_global_enabled`.
3. The coordinator's setter scheduled `_update_sensor_enabled_state`, which called `entity_registry.async_update_entity(disabled_by=None)`.
4. HA's entity-registry update flow asked the platform to re-add the entity. Its unique_id was already tracked from step 1 → duplicate-id error.

The same race fires any time the global switch toggles, because `_update_category_switches_availability` re-runs the same setter.

## Fix

Replace the registry-toggling pattern with the idiomatic `available` property that reads `coordinator.review_events_global_enabled`. The sensor stays in the registry as enabled and reports "unavailable" while the global switch is off — no runtime registry mutation, so no duplicate-add race.

### Removed
- `_update_sensor_enabled_state` (coordinator)
- `_update_entity_enabled_state` / `_handle_entity_registry_update` / `_start_event_listener` / `_stop_event_listener` / `_is_entity_enabled` / `entity_registry_enabled_default` (sensor)

The bus listener for review events is registered unconditionally in `async_added_to_hass` and torn down in `async_will_remove_from_hass`.

### Behaviour change
- The sensor is now visible in the UI even when the global switch is off (greyed out as "unavailable") instead of being hidden by a registry-disable. This is the standard HA pattern for "exists but no data right now."

## Test plan
- [x] Updated `test_sensor.py`: `test_available_when_review_events_disabled` / `_enabled` replace the old `entity_registry_enabled_default` tests
- [x] `scripts/lint` passes
- [x] `scripts/tests` passes locally (176/176)
- [x] Live smoke: toggle the global review-events switch on/off and confirm the duplicate-id error no longer appears in the log