### PR TITLE
Fix global review-events switch not restarting monitor on toggle

### DIFF
--- a/custom_components/inception/switch.py
+++ b/custom_components/inception/switch.py
@@ -358,19 +358,27 @@ class ReviewEventGlobalSwitch(SwitchEntity):
     async def async_turn_on(self) -> None:
         """Turn on the global review event listener."""
         self._attr_is_on = True
+        # Mirror the new state into the coordinator BEFORE asking the
+        # listener to (re)start. `_start_review_listener` calls
+        # `coordinator.update_review_listener_from_switches`, which checks
+        # `coordinator.review_events_global_enabled` to decide whether to
+        # start or stop the listener. If we wait until after, the listener
+        # sees the stale `False` value and stops itself instead of starting.
+        self.coordinator.review_events_global_enabled = True
         await self._save_state()
         await self._start_review_listener()
         self.async_write_ha_state()
-        # Update category switches availability
+        # Refresh dependent category switches.
         await self._update_category_switches_availability()
 
     async def async_turn_off(self) -> None:
         """Turn off the global review event listener."""
         self._attr_is_on = False
+        self.coordinator.review_events_global_enabled = False
         await self._save_state()
         await self._stop_review_listener()
         self.async_write_ha_state()
-        # Update category switches availability
+        # Refresh dependent category switches.
         await self._update_category_switches_availability()
 
     async def _start_review_listener(self) -> None:

--- a/custom_components/inception/switch.py
+++ b/custom_components/inception/switch.py
@@ -390,8 +390,19 @@ class ReviewEventGlobalSwitch(SwitchEntity):
         await self.coordinator.stop_review_listener()
 
     async def _save_state(self) -> None:
-        """Save the current state to storage."""
-        await self._store.async_save({"global_enabled": self._attr_is_on})
+        """
+        Save the current state to storage.
+
+        Merge rather than replace: the same store also holds per-category
+        flags (`security_enabled`, `system_enabled`, …) written by
+        `ReviewEventCategorySwitch`, and replacing the whole document on
+        every global toggle would wipe them — leading to
+        `update_review_listener_from_switches` warning
+        "no categories are selected" the next time the global is enabled.
+        """
+        stored_data = await self._store.async_load() or {}
+        stored_data["global_enabled"] = self._attr_is_on
+        await self._store.async_save(stored_data)
 
     async def _update_category_switches_availability(self) -> None:
         """Update the availability of all category switches."""

--- a/tests/unit/test_switch.py
+++ b/tests/unit/test_switch.py
@@ -627,3 +627,49 @@ class TestReviewEventGlobalSwitchToggle:
 async def _async_noop(*_args: object, **_kwargs: object) -> None:
     """Async no-op used as a side_effect for stubbed coroutines."""
     return
+
+
+class TestReviewEventGlobalSwitchSaveState:
+    """_save_state must merge into the store, not replace it."""
+
+    @pytest.mark.asyncio
+    async def test_save_state_preserves_category_flags(self) -> None:
+        """
+        Toggling the global switch must not wipe category flags.
+
+        The same Store holds both `global_enabled` and per-category
+        `{category}_enabled` keys written by `ReviewEventCategorySwitch`.
+        A replacing save clobbers those — leading to
+        `update_review_listener_from_switches` later warning
+        "no categories are selected" when the global is toggled back on.
+        """
+        store = MagicMock()
+        existing = {
+            "global_enabled": True,
+            "security_enabled": True,
+            "system_enabled": False,
+        }
+
+        async def _load() -> dict:
+            return existing
+
+        saved: list[dict] = []
+
+        async def _save(data: dict) -> None:
+            saved.append(data)
+
+        store.async_load = Mock(side_effect=_load)
+        store.async_save = Mock(side_effect=_save)
+
+        switch = ReviewEventGlobalSwitch.__new__(ReviewEventGlobalSwitch)
+        switch._store = store
+        switch._attr_is_on = False
+
+        await switch._save_state()
+
+        assert len(saved) == 1
+        assert saved[0] == {
+            "global_enabled": False,
+            "security_enabled": True,
+            "system_enabled": False,
+        }

--- a/tests/unit/test_switch.py
+++ b/tests/unit/test_switch.py
@@ -21,6 +21,7 @@ from custom_components.inception.switch import (
     InceptionLogicalInputSwitch,
     InceptionSwitch,
     InceptionSwitchDescription,
+    ReviewEventGlobalSwitch,
     async_setup_entry,
 )
 
@@ -530,3 +531,99 @@ class TestSwitchEntityKeys:
         ]
         assert len(isolated_switches) == 1
         assert isolated_switches[0]._attr_unique_id == "custom_input_1_input_isolated"
+
+
+class TestReviewEventGlobalSwitchToggle:
+    """Toggling the global switch must update coordinator state in the right order."""
+
+    @pytest.fixture
+    def coordinator(self) -> Mock:
+        """Build a mock coordinator that tracks the order of state changes."""
+        coordinator = MagicMock(spec=InceptionUpdateCoordinator)
+        coordinator.review_events_global_enabled = False
+        coordinator.config_entry = Mock(entry_id="entry-1")
+        coordinator.hass = Mock()
+
+        # Record the value of `review_events_global_enabled` at the moment
+        # `update_review_listener_from_switches` is called, so the test can
+        # assert the coordinator was already in the new state by then.
+        coordinator.observed_global_at_update_call = None
+
+        async def _record_and_run() -> None:
+            coordinator.observed_global_at_update_call = (
+                coordinator.review_events_global_enabled
+            )
+
+        coordinator.update_review_listener_from_switches = Mock(
+            side_effect=_record_and_run
+        )
+
+        async def _stop() -> None:
+            return
+
+        coordinator.stop_review_listener = Mock(side_effect=_stop)
+        return coordinator
+
+    def _build_switch(self, coordinator: Mock) -> object:
+        """Build a ReviewEventGlobalSwitch instance without going through __init__."""
+        switch = ReviewEventGlobalSwitch.__new__(ReviewEventGlobalSwitch)
+        switch.coordinator = coordinator
+        switch.hass = coordinator.hass
+        switch._attr_is_on = False
+        # Stub IO/UI methods.
+        switch._save_state = Mock(side_effect=_async_noop)
+        switch.async_write_ha_state = Mock()
+        switch._update_category_switches_availability = Mock(side_effect=_async_noop)
+        return switch
+
+    @pytest.mark.asyncio
+    async def test_turn_on_sets_coordinator_state_before_starting_listener(
+        self, coordinator: Mock
+    ) -> None:
+        """
+        Coordinator state must be True before the listener-start path runs.
+
+        Otherwise `update_review_listener_from_switches` reads the stale
+        False and stops the listener instead of starting it.
+        """
+        switch = self._build_switch(coordinator)
+
+        await switch.async_turn_on()
+
+        # The listener-start path saw the new (True) state.
+        assert coordinator.observed_global_at_update_call is True
+        # And final coordinator state matches the switch.
+        assert coordinator.review_events_global_enabled is True
+        assert switch._attr_is_on is True
+
+    @pytest.mark.asyncio
+    async def test_turn_off_sets_coordinator_state_before_stopping_listener(
+        self, coordinator: Mock
+    ) -> None:
+        """
+        Coordinator state must be False before the listener-stop path runs.
+
+        Symmetry with the turn-on case; keeps the coordinator's view of the
+        world consistent for any code paths the stop hook might trigger.
+        """
+        coordinator.review_events_global_enabled = True
+        switch = self._build_switch(coordinator)
+        switch._attr_is_on = True
+
+        observed: list[bool] = []
+
+        async def _record_stop() -> None:
+            observed.append(coordinator.review_events_global_enabled)
+
+        coordinator.stop_review_listener = Mock(side_effect=_record_stop)
+
+        await switch.async_turn_off()
+
+        assert observed == [False]
+        assert coordinator.review_events_global_enabled is False
+        assert switch._attr_is_on is False
+
+
+async def _async_noop(*_args: object, **_kwargs: object) -> None:
+    """Async no-op used as a side_effect for stubbed coroutines."""
+    return


### PR DESCRIPTION
## Summary

When the global review-events switch was turned off and then back on, the monitor didn't restart — the LiveReviewEvents sub-request was never re-bundled into the long-poll.

## Root cause

`ReviewEventGlobalSwitch.async_turn_on` called `_start_review_listener` **before** `_update_category_switches_availability` mirrored the new state into `coordinator.review_events_global_enabled`:

```python
async def async_turn_on(self) -> None:
    self._attr_is_on = True
    await self._save_state()
    await self._start_review_listener()   # <-- reads coordinator state HERE
    self.async_write_ha_state()
    await self._update_category_switches_availability()  # <-- sets coordinator state HERE
```

Inside `_start_review_listener` → `coordinator.update_review_listener_from_switches`:

```python
if not getattr(self, "_review_events_global_enabled", False):
    await self.stop_review_listener()
    return
```

So the listener saw the stale `False`, called `stop_review_listener()`, and the listener stayed off. The subsequent state assignment in `_update_category_switches_availability` never re-triggered a start.

## Fix

Set `coordinator.review_events_global_enabled` directly at the top of `async_turn_on` / `async_turn_off`, before the start/stop call. The existing re-assignment in `_update_category_switches_availability` is now a no-op (the setter de-dupes), but kept for clarity.

## Test plan
- [x] New `TestReviewEventGlobalSwitchToggle` class records `coordinator.review_events_global_enabled` at the moment `update_review_listener_from_switches` / `stop_review_listener` is called, asserting the correct value is already in place
- [x] `scripts/lint` passes
- [x] `scripts/tests` passes locally (179/179)
- [ ] Live smoke: toggle the global switch off then on and confirm the monitor resumes (review events are received, bundled sub-request appears in the long-poll traffic)