### PR TITLE
Register Inception controller as a panel device

### DIFF
--- a/custom_components/inception/__init__.py
+++ b/custom_components/inception/__init__.py
@@ -10,10 +10,12 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from homeassistant.const import Platform
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.storage import Store
 
 from .const import DOMAIN
 from .coordinator import InceptionUpdateCoordinator
+from .entity import panel_device_info
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
@@ -43,6 +45,14 @@ async def async_setup_entry(
     await coordinator.async_config_entry_first_refresh()
 
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
+
+    # Register the controller as a device up front so child devices that
+    # reference it via `via_device` always have a parent to attach to.
+    device_registry = dr.async_get(hass)
+    device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        **panel_device_info(coordinator),
+    )
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     entry.async_on_unload(entry.add_update_listener(async_reload_entry))

--- a/custom_components/inception/binary_sensor.py
+++ b/custom_components/inception/binary_sensor.py
@@ -14,7 +14,7 @@ from homeassistant.components.binary_sensor import (
 from homeassistant.helpers.device_registry import DeviceInfo
 
 from .const import DOMAIN, MANUFACTURER
-from .entity import InceptionEntity
+from .entity import InceptionEntity, panel_identifiers
 from .pyinception.schemas.door import DoorPublicState
 from .pyinception.schemas.input import InputPublicState
 from .util import find_matching_door
@@ -303,6 +303,7 @@ class InceptionInputBinarySensor(
                 identifiers={(DOMAIN, self._device_id)},
                 name=data.entity_info.name,
                 manufacturer=MANUFACTURER,
+                via_device=panel_identifiers(coordinator),
             )
 
 
@@ -328,4 +329,5 @@ class InceptionDoorBinarySensor(
             identifiers={(DOMAIN, self._device_id)},
             name=data.entity_info.name,
             manufacturer=MANUFACTURER,
+            via_device=panel_identifiers(coordinator),
         )

--- a/custom_components/inception/coordinator.py
+++ b/custom_components/inception/coordinator.py
@@ -68,6 +68,13 @@ class InceptionUpdateCoordinator(DataUpdateCoordinator[InceptionApiData]):
         except Exception as err:  # noqa: BLE001
             LOGGER.debug("Protocol-version probe failed: %s", err)
 
+        # Fetch the controller's system info (serial number, system name)
+        # so the panel device in Home Assistant can expose them. Non-fatal.
+        try:
+            await self.api.get_system_info()
+        except Exception as err:  # noqa: BLE001
+            LOGGER.debug("System-info probe failed: %s", err)
+
         return await super()._async_setup()
 
     async def _async_shutdown(self, _event: Any) -> None:

--- a/custom_components/inception/entity.py
+++ b/custom_components/inception/entity.py
@@ -5,15 +5,43 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from homeassistant.core import callback
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import LOGGER
+from .const import DOMAIN, LOGGER, MANUFACTURER
 from .coordinator import InceptionUpdateCoordinator
 
 if TYPE_CHECKING:
     from homeassistant.helpers.entity import EntityDescription
 
     from .pyinception.schemas.entities import InceptionSummaryEntry
+
+
+def panel_device_info(coordinator: InceptionUpdateCoordinator) -> DeviceInfo:
+    """Build the DeviceInfo for the Inception controller (panel)."""
+    entry = coordinator.config_entry
+    protocol_version = coordinator.api.protocol_version
+    system_info = coordinator.api.system_info
+    name = (
+        (system_info.system_name if system_info else "") or entry.title or "Inception"
+    )
+    serial_number = system_info.serial_number if system_info else None
+    return DeviceInfo(
+        identifiers={(DOMAIN, entry.entry_id)},
+        name=name,
+        manufacturer=MANUFACTURER,
+        model="Inception",
+        serial_number=serial_number or None,
+        sw_version=(
+            f"Protocol v{protocol_version}" if protocol_version is not None else None
+        ),
+        configuration_url=coordinator.api._host,
+    )
+
+
+def panel_identifiers(coordinator: InceptionUpdateCoordinator) -> tuple[str, str]:
+    """Return the panel device identifier tuple used as via_device for children."""
+    return (DOMAIN, coordinator.config_entry.entry_id)
 
 
 class InceptionEntity(CoordinatorEntity[InceptionUpdateCoordinator]):

--- a/custom_components/inception/lock.py
+++ b/custom_components/inception/lock.py
@@ -21,7 +21,7 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from custom_components.inception.number import DEFAULT_TIMED_UNLOCK_DURATION
 
 from .const import DOMAIN, MANUFACTURER
-from .entity import InceptionEntity
+from .entity import InceptionEntity, panel_identifiers
 from .pyinception.schemas.door import (
     DoorControlType,
     DoorPublicState,
@@ -115,6 +115,7 @@ class InceptionLock(InceptionEntity, LockEntity):
                 r"[^a-zA-Z\s]*(Lock|Strike)", "", data.entity_info.name
             ).strip(),
             manufacturer=MANUFACTURER,
+            via_device=panel_identifiers(coordinator),
         )
 
     async def _fetch_config_entities(self) -> None:

--- a/custom_components/inception/pyinception/api.py
+++ b/custom_components/inception/pyinception/api.py
@@ -17,6 +17,7 @@ from .schemas.door import DoorPublicState, DoorSummary
 from .schemas.input import InputPublicState, InputSummary
 from .schemas.output import OutputPublicState, OutputSummary
 from .schemas.review_events import LiveReviewEventsRequest
+from .schemas.system_info import SystemInfo
 from .schemas.update_monitor import (
     MonitorEntityStatesRequest,
     UpdateMonitorResponse,
@@ -77,6 +78,7 @@ class InceptionApiClient:
         self._rest_task_retry_count: int = 0
         self._rest_task_max_retry_delay: int = 300  # 5 minutes max
         self.protocol_version: int | None = None
+        self.system_info: SystemInfo | None = None
 
     T = TypeVar("T", DoorSummary, InputSummary, OutputSummary, AreaSummary)
 
@@ -140,6 +142,37 @@ class InceptionApiClient:
             _LOGGER.info("Inception API protocol version: %d", version)
             return version
         return None
+
+    async def get_system_info(self) -> SystemInfo | None:
+        """
+        Fetch the controller's SystemInfoDto from `/api/v1/system-info`.
+
+        Exposes `SerialNumber` and `SystemName`, used to populate the panel
+        device metadata shown in the Home Assistant device registry.
+        """
+        try:
+            response = await self.request(
+                method="get",
+                path="/system-info",
+            )
+        except InceptionApiClientCommunicationError as err:
+            if "404" in str(err):
+                _LOGGER.debug("Inception firmware does not expose /system-info")
+                self.system_info = None
+                return None
+            raise
+
+        if not isinstance(response, dict):
+            return None
+
+        info = SystemInfo(**response)
+        self.system_info = info
+        _LOGGER.info(
+            "Inception system info: name=%s serial=%s",
+            info.system_name,
+            info.serial_number,
+        )
+        return info
 
     async def connect(self) -> None:
         """Connect to the API."""

--- a/custom_components/inception/pyinception/schemas/system_info.py
+++ b/custom_components/inception/pyinception/schemas/system_info.py
@@ -1,0 +1,17 @@
+# ruff: noqa: ANN003
+
+"""Schema for the Inception SystemInfoDto from /api/v1/system-info."""
+
+from __future__ import annotations
+
+
+class SystemInfo:
+    """Inception SystemInfoDto."""
+
+    serial_number: str
+    system_name: str
+
+    def __init__(self, **kwargs) -> None:
+        """Initialize the object."""
+        self.serial_number = kwargs.pop("SerialNumber", "") or ""
+        self.system_name = kwargs.pop("SystemName", "") or ""

--- a/custom_components/inception/sensor.py
+++ b/custom_components/inception/sensor.py
@@ -14,11 +14,13 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN, EVENT_REVIEW_EVENT
 from .coordinator import InceptionUpdateCoordinator
+from .entity import panel_device_info
 
 if TYPE_CHECKING:
     from collections.abc import Callable
 
     from homeassistant.core import HomeAssistant
+    from homeassistant.helpers.device_registry import DeviceInfo
 
     from .data import InceptionConfigEntry
 
@@ -130,12 +132,7 @@ class InceptionLastReviewEventSensor(
         }
 
     @property
-    def device_info(self) -> dict[str, Any]:
+    def device_info(self) -> DeviceInfo:
         """Return device information about this entity."""
         coordinator = cast("InceptionUpdateCoordinator", self.coordinator)
-        return {
-            "identifiers": {(DOMAIN, coordinator.config_entry.entry_id)},
-            "name": "Inception Security System",
-            "manufacturer": "InnerRange",
-            "model": "Inception",
-        }
+        return panel_device_info(coordinator)

--- a/custom_components/inception/switch.py
+++ b/custom_components/inception/switch.py
@@ -17,7 +17,7 @@ from homeassistant.helpers.entity_registry import async_get
 from homeassistant.helpers.storage import Store
 
 from .const import DOMAIN, LOGGER
-from .entity import InceptionEntity
+from .entity import InceptionEntity, panel_device_info, panel_identifiers
 from .pyinception.schemas.input import InputPublicState, InputType
 from .pyinception.schemas.output import OutputPublicState
 from .util import find_matching_door
@@ -199,6 +199,7 @@ class InceptionInputSwitch(InceptionSwitch, SwitchEntity):
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, data.entity_info.id)},
             name=data.entity_info.name,
+            via_device=panel_identifiers(coordinator),
         )
 
     @property
@@ -323,12 +324,7 @@ class ReviewEventGlobalSwitch(SwitchEntity):
             f"{coordinator.config_entry.entry_id}_review_events_global"
         )
         self._attr_name = "Review Events"
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, coordinator.config_entry.entry_id)},
-            name="Inception Integration",
-            manufacturer="InnerRange",
-            model="Inception",
-        )
+        self._attr_device_info = panel_device_info(coordinator)
 
         # Initialize storage for persistent state
         self._store = Store(
@@ -455,12 +451,7 @@ class ReviewEventCategorySwitch(SwitchEntity):
             f"{coordinator.config_entry.entry_id}_review_events_{category.lower()}"
         )
         self._attr_name = f"Review Events {category}"
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, coordinator.config_entry.entry_id)},
-            name="Inception Integration",
-            manufacturer="InnerRange",
-            model="Inception",
-        )
+        self._attr_device_info = panel_device_info(coordinator)
 
         # Initialize storage for persistent state
         self._store = Store(


### PR DESCRIPTION
## Summary

- Promote the previously-virtual "Inception Integration" device into a proper controller/panel device, and link Doors, Inputs, Outputs, and the review-event config entities to it via `via_device` so children nest underneath in HA's device registry.
- Add `GET /api/v1/system-info` and expose `SystemName` / `SerialNumber` on the panel device, alongside the existing protocol-version probe (shown as `sw_version`) and the host URL (`configuration_url`).
- Consolidate the three review-event config entities (global switch, category switches, last-review-event sensor) onto a shared `panel_device_info()` helper instead of three hand-rolled `DeviceInfo` blocks that each disagreed on name/metadata.

The panel keeps its existing `(DOMAIN, config_entry.entry_id)` identifier, so no device/entity migration is required on upgrade.
