### PR TITLE
Add Inception trigger platform for the automation editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,6 @@ automation:
   - alias: "Alert on Door Forced Open"
     trigger:
       platform: inception
-      type: review_event
       message_value: [5505] # Input forced
       where_id: ["abc123"]
     action:

--- a/README.md
+++ b/README.md
@@ -241,6 +241,27 @@ automation:
 
 **Note:** Review events are only available if your Inception user account has permission to access the review/audit logs. If you see 404 errors in the logs, contact your system administrator to enable review event permissions.
 
+### Inception trigger platform
+
+For easier discovery in the visual automation editor, the integration also registers an `inception` trigger type. Pick **Inception** → **Review event received** from the trigger type dropdown and choose any optional filters (category, message ID, who/what/where IDs). Multiple values per field are OR-ed together; multiple fields are AND-ed.
+
+YAML equivalent:
+
+```yaml
+automation:
+  - alias: "Alert on Door Forced Open"
+    trigger:
+      platform: inception
+      type: review_event
+      message_value: [5505] # Input forced
+      where_id: ["abc123"]
+    action:
+      - service: notify.mobile_app
+        data:
+          message: "{{ trigger.event.data.description }}"
+```
+
+
 ## Installation
 
 Recommended installation is via the [Home Assistant Community Store (HACS)](https://hacs.xyz/). [![hacs_badge](https://img.shields.io/badge/HACS-Default-orange.svg)](https://github.com/custom-components/hacs)

--- a/custom_components/inception/translations/en.json
+++ b/custom_components/inception/translations/en.json
@@ -91,7 +91,7 @@
         }
     },
     "triggers": {
-        "review_event": {
+        "_": {
             "name": "Review event received",
             "description": "Fires when a review event is received from the Inception system. All filter fields are optional; leave them empty to match every event.",
             "fields": {

--- a/custom_components/inception/translations/en.json
+++ b/custom_components/inception/translations/en.json
@@ -89,5 +89,33 @@
                 }
             }
         }
+    },
+    "triggers": {
+        "review_event": {
+            "name": "Review event received",
+            "description": "Fires when a review event is received from the Inception system. All filter fields are optional; leave them empty to match every event.",
+            "fields": {
+                "message_category": {
+                    "name": "Message category",
+                    "description": "Only fire when the event belongs to one of the selected categories."
+                },
+                "message_value": {
+                    "name": "Message ID",
+                    "description": "Only fire when the event's numeric MessageID matches one of the supplied values. See the Inception API documentation for the full list of IDs."
+                },
+                "who_id": {
+                    "name": "Who ID",
+                    "description": "Only fire when the event was raised by one of the listed Inception user/entity IDs."
+                },
+                "what_id": {
+                    "name": "What ID",
+                    "description": "Only fire when the event targets one of the listed Inception entity IDs (door, area, input, output, etc.)."
+                },
+                "where_id": {
+                    "name": "Where ID",
+                    "description": "Only fire when the event occurred in one of the listed Inception area/location IDs."
+                }
+            }
+        }
     }
 }

--- a/custom_components/inception/trigger.py
+++ b/custom_components/inception/trigger.py
@@ -22,23 +22,17 @@ if TYPE_CHECKING:
     from homeassistant.helpers.trigger import TriggerActionType, TriggerInfo
     from homeassistant.helpers.typing import ConfigType
 
-CONF_EVENT_TYPE = "type"
 CONF_MESSAGE_CATEGORY = "message_category"
 CONF_MESSAGE_VALUE = "message_value"
 CONF_WHO_ID = "who_id"
 CONF_WHAT_ID = "what_id"
 CONF_WHERE_ID = "where_id"
 
-TRIGGER_REVIEW_EVENT = "review_event"
-
 MESSAGE_CATEGORIES = ["System", "Audit", "Access", "Security", "Hardware"]
 
 TRIGGER_SCHEMA = cv.TRIGGER_BASE_SCHEMA.extend(
     {
         vol.Required(CONF_PLATFORM): DOMAIN,
-        vol.Required(CONF_EVENT_TYPE, default=TRIGGER_REVIEW_EVENT): vol.In(
-            [TRIGGER_REVIEW_EVENT]
-        ),
         vol.Optional(CONF_MESSAGE_CATEGORY): vol.All(
             cv.ensure_list, [vol.In(MESSAGE_CATEGORIES)]
         ),

--- a/custom_components/inception/trigger.py
+++ b/custom_components/inception/trigger.py
@@ -1,0 +1,113 @@
+"""
+Trigger platform for the Inception integration.
+
+Exposes an ``inception`` trigger that fires on ``inception_review_event``
+events emitted by the integration's coordinator. Optional filter fields
+narrow the trigger to specific event categories or entities.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import voluptuous as vol
+from homeassistant.const import CONF_PLATFORM
+from homeassistant.core import CALLBACK_TYPE, HassJob, HomeAssistant
+from homeassistant.helpers import config_validation as cv
+
+from .const import DOMAIN, EVENT_REVIEW_EVENT
+
+if TYPE_CHECKING:
+    from homeassistant.core import Event
+    from homeassistant.helpers.trigger import TriggerActionType, TriggerInfo
+    from homeassistant.helpers.typing import ConfigType
+
+CONF_EVENT_TYPE = "type"
+CONF_MESSAGE_CATEGORY = "message_category"
+CONF_MESSAGE_VALUE = "message_value"
+CONF_WHO_ID = "who_id"
+CONF_WHAT_ID = "what_id"
+CONF_WHERE_ID = "where_id"
+
+TRIGGER_REVIEW_EVENT = "review_event"
+
+MESSAGE_CATEGORIES = ["System", "Audit", "Access", "Security", "Hardware"]
+
+TRIGGER_SCHEMA = cv.TRIGGER_BASE_SCHEMA.extend(
+    {
+        vol.Required(CONF_PLATFORM): DOMAIN,
+        vol.Required(CONF_EVENT_TYPE, default=TRIGGER_REVIEW_EVENT): vol.In(
+            [TRIGGER_REVIEW_EVENT]
+        ),
+        vol.Optional(CONF_MESSAGE_CATEGORY): vol.All(
+            cv.ensure_list, [vol.In(MESSAGE_CATEGORIES)]
+        ),
+        vol.Optional(CONF_MESSAGE_VALUE): vol.All(cv.ensure_list, [vol.Coerce(int)]),
+        vol.Optional(CONF_WHO_ID): vol.All(cv.ensure_list, [cv.string]),
+        vol.Optional(CONF_WHAT_ID): vol.All(cv.ensure_list, [cv.string]),
+        vol.Optional(CONF_WHERE_ID): vol.All(cv.ensure_list, [cv.string]),
+    }
+)
+
+
+async def async_attach_trigger(
+    hass: HomeAssistant,
+    config: ConfigType,
+    action: TriggerActionType,
+    trigger_info: TriggerInfo,
+) -> CALLBACK_TYPE:
+    """Listen for inception_review_event events matching the configured filters."""
+    trigger_data = trigger_info["trigger_data"]
+
+    categories: set[str] | None = (
+        set(config[CONF_MESSAGE_CATEGORY]) if CONF_MESSAGE_CATEGORY in config else None
+    )
+    message_values: set[int] | None = (
+        set(config[CONF_MESSAGE_VALUE]) if CONF_MESSAGE_VALUE in config else None
+    )
+    who_ids: set[str] | None = (
+        set(config[CONF_WHO_ID]) if CONF_WHO_ID in config else None
+    )
+    what_ids: set[str] | None = (
+        set(config[CONF_WHAT_ID]) if CONF_WHAT_ID in config else None
+    )
+    where_ids: set[str] | None = (
+        set(config[CONF_WHERE_ID]) if CONF_WHERE_ID in config else None
+    )
+
+    job = HassJob(action)
+
+    async def handle_event(event: Event) -> None:
+        data = event.data
+        if categories is not None and data.get("message_category") not in categories:
+            return
+        if (
+            message_values is not None
+            and data.get("message_value") not in message_values
+        ):
+            return
+        if who_ids is not None and data.get("who_id") not in who_ids:
+            return
+        if what_ids is not None and data.get("what_id") not in what_ids:
+            return
+        if where_ids is not None and data.get("where_id") not in where_ids:
+            return
+
+        task = hass.async_run_hass_job(
+            job,
+            {
+                "trigger": {
+                    **trigger_data,
+                    "platform": DOMAIN,
+                    "event": event,
+                    "description": (
+                        f"Inception review event: {data.get('description', '')}"
+                    ),
+                }
+            },
+            event.context,
+        )
+        if task:
+            await task
+
+    return hass.bus.async_listen(EVENT_REVIEW_EVENT, handle_event)

--- a/custom_components/inception/triggers.yaml
+++ b/custom_components/inception/triggers.yaml
@@ -1,4 +1,4 @@
-review_event:
+_:
   fields:
     message_category:
       required: false

--- a/custom_components/inception/triggers.yaml
+++ b/custom_components/inception/triggers.yaml
@@ -1,0 +1,32 @@
+review_event:
+  fields:
+    message_category:
+      required: false
+      selector:
+        select:
+          multiple: true
+          options:
+            - System
+            - Audit
+            - Access
+            - Security
+            - Hardware
+    message_value:
+      required: false
+      selector:
+        number:
+          mode: box
+          min: 0
+          max: 100000
+    who_id:
+      required: false
+      selector:
+        text:
+    what_id:
+      required: false
+      selector:
+        text:
+    where_id:
+      required: false
+      selector:
+        text:

--- a/tests/unit/test_trigger.py
+++ b/tests/unit/test_trigger.py
@@ -1,0 +1,65 @@
+"""Test the Inception trigger platform schema."""
+
+import pytest
+import voluptuous as vol
+
+from custom_components.inception.trigger import (
+    CONF_MESSAGE_CATEGORY,
+    CONF_MESSAGE_VALUE,
+    CONF_WHAT_ID,
+    CONF_WHERE_ID,
+    CONF_WHO_ID,
+    TRIGGER_REVIEW_EVENT,
+    TRIGGER_SCHEMA,
+)
+
+
+class TestTriggerSchema:
+    """Validate TRIGGER_SCHEMA accepts the documented shapes."""
+
+    def test_minimal_config(self) -> None:
+        """Platform alone (with defaulted type) is valid."""
+        config = TRIGGER_SCHEMA({"platform": "inception"})
+        assert config["platform"] == "inception"
+        assert config["type"] == TRIGGER_REVIEW_EVENT
+
+    def test_all_filter_fields_accepted(self) -> None:
+        """All optional filter fields coerce to lists."""
+        config = TRIGGER_SCHEMA(
+            {
+                "platform": "inception",
+                "type": TRIGGER_REVIEW_EVENT,
+                CONF_MESSAGE_CATEGORY: "Access",
+                CONF_MESSAGE_VALUE: 2011,
+                CONF_WHO_ID: "user_1",
+                CONF_WHAT_ID: ["door_1", "door_2"],
+                CONF_WHERE_ID: "area_1",
+            }
+        )
+        assert config[CONF_MESSAGE_CATEGORY] == ["Access"]
+        assert config[CONF_MESSAGE_VALUE] == [2011]
+        assert config[CONF_WHO_ID] == ["user_1"]
+        assert config[CONF_WHAT_ID] == ["door_1", "door_2"]
+        assert config[CONF_WHERE_ID] == ["area_1"]
+
+    def test_invalid_category_rejected(self) -> None:
+        """Categories outside the allowed set must fail validation."""
+        with pytest.raises(vol.Invalid):
+            TRIGGER_SCHEMA(
+                {
+                    "platform": "inception",
+                    CONF_MESSAGE_CATEGORY: "Bogus",
+                }
+            )
+
+    def test_invalid_type_rejected(self) -> None:
+        """Unknown trigger types must fail validation."""
+        with pytest.raises(vol.Invalid):
+            TRIGGER_SCHEMA({"platform": "inception", "type": "not_a_trigger"})
+
+    def test_message_value_coerces_strings(self) -> None:
+        """String message IDs are coerced to ints."""
+        config = TRIGGER_SCHEMA(
+            {"platform": "inception", CONF_MESSAGE_VALUE: ["5505", "5506"]}
+        )
+        assert config[CONF_MESSAGE_VALUE] == [5505, 5506]

--- a/tests/unit/test_trigger.py
+++ b/tests/unit/test_trigger.py
@@ -9,7 +9,6 @@ from custom_components.inception.trigger import (
     CONF_WHAT_ID,
     CONF_WHERE_ID,
     CONF_WHO_ID,
-    TRIGGER_REVIEW_EVENT,
     TRIGGER_SCHEMA,
 )
 
@@ -18,17 +17,15 @@ class TestTriggerSchema:
     """Validate TRIGGER_SCHEMA accepts the documented shapes."""
 
     def test_minimal_config(self) -> None:
-        """Platform alone (with defaulted type) is valid."""
+        """Platform alone is valid."""
         config = TRIGGER_SCHEMA({"platform": "inception"})
         assert config["platform"] == "inception"
-        assert config["type"] == TRIGGER_REVIEW_EVENT
 
     def test_all_filter_fields_accepted(self) -> None:
         """All optional filter fields coerce to lists."""
         config = TRIGGER_SCHEMA(
             {
                 "platform": "inception",
-                "type": TRIGGER_REVIEW_EVENT,
                 CONF_MESSAGE_CATEGORY: "Access",
                 CONF_MESSAGE_VALUE: 2011,
                 CONF_WHO_ID: "user_1",
@@ -51,11 +48,6 @@ class TestTriggerSchema:
                     CONF_MESSAGE_CATEGORY: "Bogus",
                 }
             )
-
-    def test_invalid_type_rejected(self) -> None:
-        """Unknown trigger types must fail validation."""
-        with pytest.raises(vol.Invalid):
-            TRIGGER_SCHEMA({"platform": "inception", "type": "not_a_trigger"})
 
     def test_message_value_coerces_strings(self) -> None:
         """String message IDs are coerced to ints."""


### PR DESCRIPTION
## Summary

Registers an `inception` trigger platform so the visual automation editor surfaces **Inception → Review event received** in the trigger-type picker, instead of users needing to know the raw `inception_review_event` event name. The trigger wraps the existing bus event with optional list-coerced filters: `message_category`, `message_value`, `who_id`, `what_id`, `where_id`. Within a field values OR; across fields they AND.

YAML form:

```yaml
trigger:
  platform: inception
  message_category: [Access]
  where_id: ["abc123"]
```

Existing automations using `platform: event` / `event_type: inception_review_event` continue to work unchanged.