### PR TITLE
Add get_review_events service for querying historical events

### DIFF
--- a/custom_components/inception/__init__.py
+++ b/custom_components/inception/__init__.py
@@ -16,6 +16,7 @@ from homeassistant.helpers.storage import Store
 from .const import DOMAIN
 from .coordinator import InceptionUpdateCoordinator
 from .entity import panel_device_info
+from .services import async_register_services, async_unregister_services
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
@@ -57,6 +58,8 @@ async def async_setup_entry(
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     entry.async_on_unload(entry.add_update_listener(async_reload_entry))
 
+    async_register_services(hass)
+
     return True
 
 
@@ -75,6 +78,8 @@ async def async_unload_entry(
 
     # Remove the coordinator from hass.data
     hass.data[DOMAIN].pop(entry.entry_id)
+
+    async_unregister_services(hass)
 
     return True
 

--- a/custom_components/inception/pyinception/api.py
+++ b/custom_components/inception/pyinception/api.py
@@ -645,6 +645,62 @@ class InceptionApiClient:
         """Send a control payload to an input."""
         return await self._control_item(item=f"input/{input_id}", data=data)
 
+    async def get_review_events(  # noqa: PLR0913
+        self,
+        *,
+        limit: int | None = None,
+        offset: int | None = None,
+        direction: str | None = None,
+        start: str | None = None,
+        end: str | None = None,
+        category_filter: list[str] | None = None,
+        message_type_id_filter: list[int] | None = None,
+        involved_entity_id_filter: list[str] | None = None,
+        reference_id: str | None = None,
+        reference_time: int | None = None,
+    ) -> list[dict[str, Any]]:
+        """
+        Query historical review events via `GET /api/v1/review`.
+
+        Any parameter left as `None` is omitted from the query. The Inception
+        controller returns either a wrapped `{"Offset", "Count", "Data": [...]}`
+        envelope or, for some firmware versions, a bare list. Both shapes are
+        normalised to a list of event dicts before returning.
+        """
+        candidates: list[tuple[str, Any]] = [
+            ("limit", limit),
+            ("offset", offset),
+            ("dir", direction),
+            ("start", start),
+            ("end", end),
+            ("referenceId", reference_id),
+            ("referenceTime", reference_time),
+        ]
+        params: dict[str, str] = {
+            key: str(value) for key, value in candidates if value is not None
+        }
+        if category_filter:
+            params["categoryFilter"] = ",".join(category_filter)
+        if message_type_id_filter:
+            params["messageTypeIdFilter"] = ",".join(
+                str(value) for value in message_type_id_filter
+            )
+        if involved_entity_id_filter:
+            params["involvedEntityIdFilter"] = ",".join(involved_entity_id_filter)
+
+        query_params = urlencode(params)
+        response = await self._review_events_request(query_params)
+
+        if response is None:
+            return []
+        if isinstance(response, list):
+            return response
+        if isinstance(response, dict):
+            data = response.get("Data", [])
+            if isinstance(data, list):
+                return data
+        return []
+
     async def start_review_listener(self, categories: list[str]) -> None:
         """
         Enable bundled review-event polling on the next long-poll iteration.

--- a/custom_components/inception/services.py
+++ b/custom_components/inception/services.py
@@ -1,0 +1,135 @@
+"""Service handlers for the Inception integration."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import voluptuous as vol
+from homeassistant.core import (
+    HomeAssistant,
+    ServiceCall,
+    ServiceResponse,
+    SupportsResponse,
+    callback,
+)
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
+from homeassistant.helpers import config_validation as cv
+
+from .const import DOMAIN, LOGGER
+
+if TYPE_CHECKING:
+    from .coordinator import InceptionUpdateCoordinator
+
+SERVICE_GET_REVIEW_EVENTS = "get_review_events"
+
+ATTR_ENTRY_ID = "entry_id"
+ATTR_LIMIT = "limit"
+ATTR_OFFSET = "offset"
+ATTR_DIRECTION = "direction"
+ATTR_START = "start"
+ATTR_END = "end"
+ATTR_CATEGORY_FILTER = "category_filter"
+ATTR_MESSAGE_TYPE_ID_FILTER = "message_type_id_filter"
+ATTR_INVOLVED_ENTITY_ID_FILTER = "involved_entity_id_filter"
+ATTR_REFERENCE_ID = "reference_id"
+ATTR_REFERENCE_TIME = "reference_time"
+
+REVIEW_CATEGORIES = ["System", "Audit", "Access", "Security", "Hardware"]
+
+GET_REVIEW_EVENTS_SCHEMA = vol.Schema(
+    {
+        vol.Optional(ATTR_ENTRY_ID): cv.string,
+        vol.Optional(ATTR_LIMIT): vol.All(vol.Coerce(int), vol.Range(min=1, max=1000)),
+        vol.Optional(ATTR_OFFSET): vol.All(vol.Coerce(int), vol.Range(min=0)),
+        vol.Optional(ATTR_DIRECTION): vol.In(["asc", "desc"]),
+        vol.Optional(ATTR_START): cv.string,
+        vol.Optional(ATTR_END): cv.string,
+        vol.Optional(ATTR_CATEGORY_FILTER): vol.All(
+            cv.ensure_list, [vol.In(REVIEW_CATEGORIES)]
+        ),
+        vol.Optional(ATTR_MESSAGE_TYPE_ID_FILTER): vol.All(
+            cv.ensure_list, [vol.Coerce(int)]
+        ),
+        vol.Optional(ATTR_INVOLVED_ENTITY_ID_FILTER): vol.All(
+            cv.ensure_list, [cv.string]
+        ),
+        vol.Optional(ATTR_REFERENCE_ID): cv.string,
+        vol.Optional(ATTR_REFERENCE_TIME): vol.All(vol.Coerce(int), vol.Range(min=0)),
+    }
+)
+
+
+def _resolve_coordinator(
+    hass: HomeAssistant, entry_id: str | None
+) -> InceptionUpdateCoordinator:
+    """Return the coordinator for ``entry_id`` (or the only loaded one)."""
+    coordinators: dict[str, InceptionUpdateCoordinator] = hass.data.get(DOMAIN, {})
+
+    if not coordinators:
+        msg = "No Inception integrations are configured."
+        raise ServiceValidationError(msg)
+
+    if entry_id is not None:
+        coordinator = coordinators.get(entry_id)
+        if coordinator is None:
+            msg = f"No Inception integration found for entry_id '{entry_id}'."
+            raise ServiceValidationError(msg)
+        return coordinator
+
+    if len(coordinators) > 1:
+        msg = (
+            "Multiple Inception integrations are configured; "
+            "provide 'entry_id' to select one."
+        )
+        raise ServiceValidationError(msg)
+
+    return next(iter(coordinators.values()))
+
+
+@callback
+def async_register_services(hass: HomeAssistant) -> None:
+    """Register Inception domain services. Safe to call multiple times."""
+    if hass.services.has_service(DOMAIN, SERVICE_GET_REVIEW_EVENTS):
+        return
+
+    async def async_get_review_events(call: ServiceCall) -> ServiceResponse:
+        """Query historical review events from the Inception controller."""
+        coordinator = _resolve_coordinator(hass, call.data.get(ATTR_ENTRY_ID))
+
+        kwargs: dict[str, Any] = {
+            "limit": call.data.get(ATTR_LIMIT),
+            "offset": call.data.get(ATTR_OFFSET),
+            "direction": call.data.get(ATTR_DIRECTION),
+            "start": call.data.get(ATTR_START),
+            "end": call.data.get(ATTR_END),
+            "category_filter": call.data.get(ATTR_CATEGORY_FILTER),
+            "message_type_id_filter": call.data.get(ATTR_MESSAGE_TYPE_ID_FILTER),
+            "involved_entity_id_filter": call.data.get(ATTR_INVOLVED_ENTITY_ID_FILTER),
+            "reference_id": call.data.get(ATTR_REFERENCE_ID),
+            "reference_time": call.data.get(ATTR_REFERENCE_TIME),
+        }
+
+        try:
+            events = await coordinator.api.get_review_events(**kwargs)
+        except Exception as err:
+            LOGGER.exception("Failed to fetch review events")
+            msg = f"Failed to fetch review events: {err}"
+            raise HomeAssistantError(msg) from err
+
+        return {"events": events, "count": len(events)}
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_GET_REVIEW_EVENTS,
+        async_get_review_events,
+        schema=GET_REVIEW_EVENTS_SCHEMA,
+        supports_response=SupportsResponse.ONLY,
+    )
+
+
+@callback
+def async_unregister_services(hass: HomeAssistant) -> None:
+    """Remove Inception domain services when the last entry unloads."""
+    if hass.data.get(DOMAIN):
+        return
+    hass.services.async_remove(DOMAIN, SERVICE_GET_REVIEW_EVENTS)

--- a/custom_components/inception/services.yaml
+++ b/custom_components/inception/services.yaml
@@ -28,3 +28,75 @@ area_arm:
       required: false
       selector:
         text:
+
+get_review_events:
+  fields:
+    entry_id:
+      required: false
+      selector:
+        config_entry:
+          integration: inception
+    limit:
+      required: false
+      default: 100
+      selector:
+        number:
+          min: 1
+          max: 1000
+          mode: box
+    offset:
+      required: false
+      selector:
+        number:
+          min: 0
+          max: 100000
+          mode: box
+    direction:
+      required: false
+      selector:
+        select:
+          options:
+            - value: asc
+              label: Oldest first
+            - value: desc
+              label: Newest first
+    start:
+      required: false
+      selector:
+        datetime:
+    end:
+      required: false
+      selector:
+        datetime:
+    category_filter:
+      required: false
+      selector:
+        select:
+          multiple: true
+          options:
+            - System
+            - Audit
+            - Access
+            - Security
+            - Hardware
+    message_type_id_filter:
+      required: false
+      example: "5000, 5201"
+      selector:
+        object:
+    involved_entity_id_filter:
+      required: false
+      example: "fbec7c22-500d-4f3b-b94e-4c19ff501f9f"
+      selector:
+        object:
+    reference_id:
+      required: false
+      selector:
+        text:
+    reference_time:
+      required: false
+      selector:
+        number:
+          min: 0
+          max: 9999999999999999999
+          mode: box

--- a/custom_components/inception/translations/en.json
+++ b/custom_components/inception/translations/en.json
@@ -77,6 +77,56 @@
                     "description": "PIN code for arming the area. If omitted, defaults to the user which is associated with the configured API token."
                 }
             }
+        },
+        "get_review_events": {
+            "name": "Get review events",
+            "description": "Queries historical review events from the Inception controller. Returns matching events as a service response. All fields are optional; leave them empty to fetch the most recent events.",
+            "fields": {
+                "entry_id": {
+                    "name": "Inception hub",
+                    "description": "Select which configured Inception hub to query. Only required when multiple hubs are configured."
+                },
+                "limit": {
+                    "name": "Limit",
+                    "description": "Maximum number of events to return. Defaults to 100 when omitted."
+                },
+                "offset": {
+                    "name": "Offset",
+                    "description": "Skip this many events before returning results. Use with 'limit' for pagination."
+                },
+                "direction": {
+                    "name": "Direction",
+                    "description": "Sort order. 'Oldest first' (asc) is the default; 'Newest first' (desc) returns the most recent events."
+                },
+                "start": {
+                    "name": "Start",
+                    "description": "Earliest event timestamp to include. When using 'Newest first', this must be more recent than 'End'."
+                },
+                "end": {
+                    "name": "End",
+                    "description": "Latest event timestamp to include."
+                },
+                "category_filter": {
+                    "name": "Categories",
+                    "description": "Only return events in one or more of the selected categories."
+                },
+                "message_type_id_filter": {
+                    "name": "Message type IDs",
+                    "description": "Only return events whose numeric MessageID matches one of the supplied values. Provide a list of integers."
+                },
+                "involved_entity_id_filter": {
+                    "name": "Involved entity IDs",
+                    "description": "Only return events whose WhoID, WhatID or WhereID matches one of the supplied entity IDs. Provide a list of UUID strings."
+                },
+                "reference_id": {
+                    "name": "Reference event ID",
+                    "description": "Anchor pagination around a specific event. Pair with 'Reference time' (the event's WhenTicks value)."
+                },
+                "reference_time": {
+                    "name": "Reference time",
+                    "description": "WhenTicks value of the reference event. Must be supplied alongside 'Reference event ID'."
+                }
+            }
         }
     },
     "entity": {

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -781,3 +781,103 @@ class TestBundledLongPoll:
 
         assert api_client._review_events_enabled is False
         assert api_client._review_events_categories == []
+
+
+class TestGetReviewEvents:
+    """Test the get_review_events query helper."""
+
+    @pytest.fixture
+    def mock_session(self) -> Mock:
+        """Create a mock session."""
+        return Mock(spec=aiohttp.ClientSession)
+
+    @pytest.mark.asyncio
+    async def test_passes_filters_as_query_params(self, mock_session: Mock) -> None:
+        """All supplied filters are serialised into the request query string."""
+        api_client = InceptionApiClient(
+            token="t", host="http://h.test", session=mock_session
+        )
+
+        captured: dict[str, Any] = {}
+
+        async def fake_request(query_params: str) -> dict[str, Any]:
+            captured["query"] = query_params
+            return {"Offset": 0, "Count": 1, "Data": [{"ID": "event-1"}]}
+
+        api_client._review_events_request = fake_request  # type: ignore[assignment]
+
+        events = await api_client.get_review_events(
+            limit=50,
+            offset=10,
+            direction="desc",
+            start="2025-01-01T00:00:00",
+            end="2025-01-02T00:00:00",
+            category_filter=["Access", "Security"],
+            message_type_id_filter=[5000, 5201],
+            involved_entity_id_filter=["abc"],
+            reference_id="ref",
+            reference_time=12345,
+        )
+
+        assert events == [{"ID": "event-1"}]
+        query = captured["query"]
+        assert "limit=50" in query
+        assert "offset=10" in query
+        assert "dir=desc" in query
+        assert "categoryFilter=Access%2CSecurity" in query
+        assert "messageTypeIdFilter=5000%2C5201" in query
+        assert "involvedEntityIdFilter=abc" in query
+        assert "referenceId=ref" in query
+        assert "referenceTime=12345" in query
+
+    @pytest.mark.asyncio
+    async def test_omits_none_params(self, mock_session: Mock) -> None:
+        """Parameters left as None are not included in the query string."""
+        api_client = InceptionApiClient(
+            token="t", host="http://h.test", session=mock_session
+        )
+
+        captured: dict[str, Any] = {}
+
+        async def fake_request(query_params: str) -> list[dict[str, Any]]:
+            captured["query"] = query_params
+            return []
+
+        api_client._review_events_request = fake_request  # type: ignore[assignment]
+
+        events = await api_client.get_review_events(limit=5)
+
+        assert events == []
+        assert captured["query"] == "limit=5"
+
+    @pytest.mark.asyncio
+    async def test_handles_bare_list_response(self, mock_session: Mock) -> None:
+        """Firmware variants returning a bare list are normalised."""
+        api_client = InceptionApiClient(
+            token="t", host="http://h.test", session=mock_session
+        )
+
+        async def fake_request(_query_params: str) -> list[dict[str, Any]]:
+            return [{"ID": "event-1"}, {"ID": "event-2"}]
+
+        api_client._review_events_request = fake_request  # type: ignore[assignment]
+
+        events = await api_client.get_review_events()
+
+        assert events == [{"ID": "event-1"}, {"ID": "event-2"}]
+
+    @pytest.mark.asyncio
+    async def test_handles_none_response(self, mock_session: Mock) -> None:
+        """Empty / None responses are surfaced as an empty list."""
+        api_client = InceptionApiClient(
+            token="t", host="http://h.test", session=mock_session
+        )
+
+        async def fake_request(_query_params: str) -> None:
+            return None
+
+        api_client._review_events_request = fake_request  # type: ignore[assignment]
+
+        events = await api_client.get_review_events()
+
+        assert events == []

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -1,0 +1,137 @@
+"""Tests for the Inception domain services."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
+
+from custom_components.inception.const import DOMAIN
+from custom_components.inception.services import (
+    SERVICE_GET_REVIEW_EVENTS,
+    _resolve_coordinator,
+    async_register_services,
+)
+
+
+def _hass_with_coordinators(coordinators: dict[str, Any]) -> MagicMock:
+    """Build a minimal hass stub that records service registrations."""
+    hass = MagicMock()
+    hass.data = {DOMAIN: coordinators} if coordinators else {}
+    hass.services.has_service.return_value = False
+    hass.services.async_register = MagicMock()
+    hass.services.async_remove = MagicMock()
+    return hass
+
+
+class TestResolveCoordinator:
+    """Test the entry-id resolution helper."""
+
+    def test_raises_when_no_integrations(self) -> None:
+        """No configured integrations is a user-facing validation error."""
+        hass = _hass_with_coordinators({})
+        with pytest.raises(ServiceValidationError):
+            _resolve_coordinator(hass, None)
+
+    def test_returns_single_coordinator_implicitly(self) -> None:
+        """A single configured entry is selected without an entry_id."""
+        coordinator = MagicMock()
+        hass = _hass_with_coordinators({"only": coordinator})
+        assert _resolve_coordinator(hass, None) is coordinator
+
+    def test_requires_entry_id_when_multiple(self) -> None:
+        """Multiple entries without entry_id raises a validation error."""
+        hass = _hass_with_coordinators({"a": MagicMock(), "b": MagicMock()})
+        with pytest.raises(ServiceValidationError):
+            _resolve_coordinator(hass, None)
+
+    def test_returns_named_entry(self) -> None:
+        """Explicit entry_id resolves to the matching coordinator."""
+        wanted = MagicMock()
+        hass = _hass_with_coordinators({"a": MagicMock(), "b": wanted})
+        assert _resolve_coordinator(hass, "b") is wanted
+
+    def test_unknown_entry_id_raises(self) -> None:
+        """An entry_id that doesn't match any configured entry is rejected."""
+        hass = _hass_with_coordinators({"a": MagicMock()})
+        with pytest.raises(ServiceValidationError):
+            _resolve_coordinator(hass, "missing")
+
+
+class TestAsyncRegisterServices:
+    """Test the service registration entry point."""
+
+    def test_registers_get_review_events_once(self) -> None:
+        """async_register_services registers the get_review_events service."""
+        hass = _hass_with_coordinators({"a": MagicMock()})
+        async_register_services(hass)
+
+        hass.services.async_register.assert_called_once()
+        call_args = hass.services.async_register.call_args
+        assert call_args.args[0] == DOMAIN
+        assert call_args.args[1] == SERVICE_GET_REVIEW_EVENTS
+
+    def test_skips_when_already_registered(self) -> None:
+        """Re-invocation is a no-op so multiple entries don't double-register."""
+        hass = _hass_with_coordinators({"a": MagicMock()})
+        hass.services.has_service.return_value = True
+
+        async_register_services(hass)
+
+        hass.services.async_register.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_handler_calls_api_and_returns_events(self) -> None:
+        """The registered handler delegates to the coordinator's API client."""
+        coordinator = MagicMock()
+        coordinator.api.get_review_events = AsyncMock(
+            return_value=[{"ID": "evt-1"}, {"ID": "evt-2"}]
+        )
+        hass = _hass_with_coordinators({"only": coordinator})
+
+        async_register_services(hass)
+        handler = hass.services.async_register.call_args.args[2]
+
+        call = MagicMock()
+        call.data = {
+            "limit": 50,
+            "direction": "desc",
+            "category_filter": ["Access"],
+        }
+
+        response = await handler(call)
+
+        coordinator.api.get_review_events.assert_awaited_once_with(
+            limit=50,
+            offset=None,
+            direction="desc",
+            start=None,
+            end=None,
+            category_filter=["Access"],
+            message_type_id_filter=None,
+            involved_entity_id_filter=None,
+            reference_id=None,
+            reference_time=None,
+        )
+        assert response == {
+            "events": [{"ID": "evt-1"}, {"ID": "evt-2"}],
+            "count": 2,
+        }
+
+    @pytest.mark.asyncio
+    async def test_handler_wraps_api_errors(self) -> None:
+        """Unexpected API errors surface as HomeAssistantError."""
+        coordinator = MagicMock()
+        coordinator.api.get_review_events = AsyncMock(side_effect=RuntimeError("boom"))
+        hass = _hass_with_coordinators({"only": coordinator})
+
+        async_register_services(hass)
+        handler = hass.services.async_register.call_args.args[2]
+
+        call = MagicMock()
+        call.data = {}
+
+        with pytest.raises(HomeAssistantError):
+            await handler(call)


### PR DESCRIPTION
## Summary

- Adds an `inception.get_review_events` domain service that exposes the controller's `GET /api/v1/review` endpoint, returning matching events as a service response (`SupportsResponse.ONLY`).
- Supports the full filter set: `limit`, `offset`, `direction`, `start`/`end`, `category_filter`, `message_type_id_filter`, `involved_entity_id_filter`, and `reference_id`/`reference_time` for cursor-style pagination. `entry_id` is optional when only one Inception hub is configured.
- Normalises both the `{Offset, Count, Data: [...]}` envelope and the bare-list response shape into a list of event dicts.

## Test plan

- [x] `scripts/lint` passes
- [x] `scripts/tests` passes (204 tests, including 13 new ones covering query-param serialisation, response normalisation, entry-id resolution, registration idempotency, and the handler delegating to the API client)
- [x] Manual smoke test: call the service from Developer Tools with combinations of filters against a real Inception controller and verify the returned events match the web UI's review log