### PR TITLE
Add service, select state, and entity icons

### DIFF
--- a/custom_components/inception/icons.json
+++ b/custom_components/inception/icons.json
@@ -1,7 +1,21 @@
 {
-  "triggers": {
-    "_": {
-      "trigger": "mdi:shield-alert-outline"
+  "entity": {
+    "select": {
+      "unlock_strategy": {
+        "default": "mdi:timer-lock-open",
+        "state": {
+          "unlock": "mdi:lock-open-variant",
+          "timed_unlock": "mdi:timer-lock-open-outline"
+        }
+      }
     }
+  },
+  "services": {
+    "unlock": { "service": "mdi:lock-open-variant" },
+    "area_arm": { "service": "mdi:shield-home" },
+    "get_review_events": { "service": "mdi:history" }
+  },
+  "triggers": {
+    "_": { "trigger": "mdi:shield-alert-outline" }
   }
 }


### PR DESCRIPTION
## Summary

Extends `icons.json` so the integration's services and select states render with purpose-specific icons in the UI instead of the generic action glyph.

- Services: `unlock` → `mdi:lock-open-variant`, `area_arm` → `mdi:shield-home`, `get_review_events` → `mdi:history`
- `select.unlock_strategy`: default `mdi:timer-lock-open`; states `unlock` → `mdi:lock-open-variant`, `timed_unlock` → `mdi:timer-lock-open-outline`
- Trigger icon (already on main from previous commit) preserved

## Test plan

- [x] `scripts/lint`
- [x] `scripts/tests` (204 passing)
- [x] Manual: restart HA, confirm icons render in Developer Tools → Actions and on the `unlock_strategy` select states.