### PR TITLE
Add virtual badge, PIN, and reader discovery services

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,8 +161,8 @@ data:
 Virtually badges a user credential at a door reader, as though the card had been physically presented. The Inception controller carries out the resulting access attempt (grant / deny / review-event emission) exactly as it would for a real swipe.
 
 **Parameters:**
-- `reader_id` (required): ID of the reader to badge at. Discover reader IDs via the [`inception.get_attached_readers`](#inceptionget_attached_readers) service.
-- `credential_template` (required): The Credential Template ID of the user credential. Available from the user's `PhysicalCredentials[]` entry in the Inception API.
+- `reader_id` (required): ID of the reader to badge at. Reader IDs are attributes of a lock, or can be discovered via the [`inception.get_attached_readers`](#inceptionget_attached_readers) service.
+- `credential_template` (required): The Credential Template ID of the user credential. Find the ID at Inception > System > API Details.
 - `card_number` (required): The card number (Credential `Data` value) of the user credential.
 - `entry_id` (optional): Select which configured Inception hub to target. Only required when multiple hubs are configured.
 
@@ -183,7 +183,7 @@ response_variable: result
 Virtually presents a User PIN at a door reader, as though it had been physically entered on the keypad.
 
 **Parameters:**
-- `reader_id` (required): ID of the reader to present the PIN at. Discover reader IDs via the [`inception.get_attached_readers`](#inceptionget_attached_readers) service.
+- `reader_id` (required): ID of the reader to present the PIN at. Reader IDs are attributes of a lock, or can be discovered via the [`inception.get_attached_readers`](#inceptionget_attached_readers) service.
 - `pin` (required): The User PIN to present. PINs cannot be retrieved from the Inception API (they are write-only for security), so the caller must know the value.
 - `entry_id` (optional): Select which configured Inception hub to target. Only required when multiple hubs are configured.
 

--- a/README.md
+++ b/README.md
@@ -156,6 +156,93 @@ data:
   code: "1234"
 ```
 
+### inception.badge_credential
+
+Virtually badges a user credential at a door reader, as though the card had been physically presented. The Inception controller carries out the resulting access attempt (grant / deny / review-event emission) exactly as it would for a real swipe.
+
+**Parameters:**
+- `reader_id` (required): ID of the reader to badge at. Discover reader IDs via the [`inception.get_attached_readers`](#inceptionget_attached_readers) service.
+- `credential_template` (required): The Credential Template ID of the user credential. Available from the user's `PhysicalCredentials[]` entry in the Inception API.
+- `card_number` (required): The card number (Credential `Data` value) of the user credential.
+- `entry_id` (optional): Select which configured Inception hub to target. Only required when multiple hubs are configured.
+
+**Response:** A service response containing `activity_id` — the controller's `ActivityID` for the submitted activity, useful for cross-referencing review events.
+
+**Example:**
+```yaml
+service: inception.badge_credential
+data:
+  reader_id: "5a1b8b27-3d0c-4d52-9f72-3f0e5b9d4a52"
+  credential_template: "0f8c5e94-5cb7-4f3f-9b66-2e2e3c0a5d33"
+  card_number: "0000123"
+response_variable: result
+```
+
+### inception.send_pin
+
+Virtually presents a User PIN at a door reader, as though it had been physically entered on the keypad.
+
+**Parameters:**
+- `reader_id` (required): ID of the reader to present the PIN at. Discover reader IDs via the [`inception.get_attached_readers`](#inceptionget_attached_readers) service.
+- `pin` (required): The User PIN to present. PINs cannot be retrieved from the Inception API (they are write-only for security), so the caller must know the value.
+- `entry_id` (optional): Select which configured Inception hub to target. Only required when multiple hubs are configured.
+
+**Response:** A service response containing `activity_id` — the controller's `ActivityID` for the submitted activity.
+
+**Example:**
+```yaml
+service: inception.send_pin
+data:
+  reader_id: "5a1b8b27-3d0c-4d52-9f72-3f0e5b9d4a52"
+  pin: "1234"
+response_variable: result
+```
+
+### inception.get_attached_readers
+
+Returns the readers attached to a door. Use the resulting reader IDs with [`inception.badge_credential`](#inceptionbadge_credential) and [`inception.send_pin`](#inceptionsend_pin). Reader IDs are stable, so you typically only need to call this once per automation while wiring it up.
+
+**Parameters:**
+- `door_id` (required): The Inception ID of the door to list readers for. Available as the `unique_id` of the door's lock entity in Home Assistant.
+- `entry_id` (optional): Select which configured Inception hub to query. Only required when multiple hubs are configured.
+
+**Response:** A service response containing `readers` (the list of reader objects, each with `ID` and `Name`) and `count`.
+
+**Example:**
+```yaml
+service: inception.get_attached_readers
+data:
+  door_id: "fbec7c22-500d-4f3b-b94e-4c19ff501f9f"
+response_variable: result
+```
+
+### inception.get_review_events
+
+Queries historical review events from the Inception controller. Returns matching events as a service response.
+
+**Parameters:** All optional. Leave them empty to fetch the most recent events.
+- `limit`: Maximum number of events to return (default 100, max 1000).
+- `offset`: Skip this many events before returning results. Use with `limit` for pagination.
+- `direction`: `asc` (oldest first, default) or `desc` (newest first).
+- `start` / `end`: Earliest / latest event timestamp to include.
+- `category_filter`: One or more of `System`, `Audit`, `Access`, `Security`, `Hardware`.
+- `message_type_id_filter`: A list of numeric `MessageID` values to match.
+- `involved_entity_id_filter`: A list of UUID strings — events whose `WhoID`, `WhatID`, or `WhereID` matches will be returned.
+- `reference_id` / `reference_time`: Anchor pagination around a specific event (the event's ID and its `WhenTicks` value).
+- `entry_id`: Select which configured Inception hub to query. Only required when multiple hubs are configured.
+
+**Response:** A service response containing `events` (the list of event records) and `count`.
+
+**Example:**
+```yaml
+service: inception.get_review_events
+data:
+  limit: 50
+  direction: desc
+  category_filter: [Access, Security]
+response_variable: result
+```
+
 ## Events
 
 The integration emits Home Assistant events for real-time security notifications:

--- a/custom_components/inception/icons.json
+++ b/custom_components/inception/icons.json
@@ -13,7 +13,10 @@
   "services": {
     "unlock": { "service": "mdi:lock-open-variant" },
     "area_arm": { "service": "mdi:shield-home" },
-    "get_review_events": { "service": "mdi:history" }
+    "get_review_events": { "service": "mdi:history" },
+    "get_attached_readers": { "service": "mdi:smart-card-reader-outline" },
+    "badge_credential": { "service": "mdi:badge-account-outline" },
+    "send_pin": { "service": "mdi:numeric" }
   },
   "triggers": {
     "_": { "trigger": "mdi:shield-alert-outline" }

--- a/custom_components/inception/pyinception/api.py
+++ b/custom_components/inception/pyinception/api.py
@@ -645,6 +645,70 @@ class InceptionApiClient:
         """Send a control payload to an input."""
         return await self._control_item(item=f"input/{input_id}", data=data)
 
+    async def get_attached_readers(self, door_id: str) -> list[dict[str, Any]]:
+        """List readers attached to ``door_id`` via the control endpoint."""
+        response = await self.request(
+            method="get",
+            path=f"/control/door/{door_id}/attached-readers",
+        )
+        if isinstance(response, list):
+            return response
+        return []
+
+    async def _submit_activity(self, payload: dict[str, Any]) -> str | None:
+        """
+        POST ``payload`` to ``/api/v1/activity`` and return the ActivityID.
+
+        Returns ``None`` if the server reports a ``Failure`` result. Network
+        / HTTP errors propagate as the usual ``InceptionApiClientError``
+        subclasses so callers can map them to ``HomeAssistantError``.
+        """
+        response = await self.request(
+            method="post",
+            path="/activity",
+            data=payload,
+        )
+        if not isinstance(response, dict):
+            return None
+        result = response.get("Response", {})
+        if isinstance(result, dict) and result.get("Result") == "Success":
+            activity_id = response.get("ActivityID")
+            if isinstance(activity_id, str):
+                return activity_id
+        message = "Unknown"
+        if isinstance(result, dict):
+            message = str(result.get("Message", message))
+        msg = f"Activity submission failed: {message}"
+        raise InceptionApiClientError(msg)
+
+    async def badge_credential_at_reader(
+        self,
+        reader_id: str,
+        credential_template: str,
+        card_number: str,
+    ) -> str | None:
+        """Virtually badge a credential at a reader. Returns the ActivityID."""
+        return await self._submit_activity(
+            {
+                "Type": "BadgeCredentialAtReader",
+                "CredentialData": {
+                    "CredentialTemplate": credential_template,
+                    "Data": card_number,
+                },
+                "Entity": reader_id,
+            }
+        )
+
+    async def send_pin_to_reader(self, reader_id: str, pin: str) -> str | None:
+        """Virtually present a User PIN at a reader. Returns the ActivityID."""
+        return await self._submit_activity(
+            {
+                "Type": "SendPINDataToReader",
+                "Entity": reader_id,
+                "PINData": pin,
+            }
+        )
+
     async def get_review_events(  # noqa: PLR0913
         self,
         *,

--- a/custom_components/inception/services.py
+++ b/custom_components/inception/services.py
@@ -21,6 +21,9 @@ if TYPE_CHECKING:
     from .coordinator import InceptionUpdateCoordinator
 
 SERVICE_GET_REVIEW_EVENTS = "get_review_events"
+SERVICE_BADGE_CREDENTIAL = "badge_credential"
+SERVICE_SEND_PIN = "send_pin"
+SERVICE_GET_ATTACHED_READERS = "get_attached_readers"
 
 ATTR_ENTRY_ID = "entry_id"
 ATTR_LIMIT = "limit"
@@ -33,8 +36,37 @@ ATTR_MESSAGE_TYPE_ID_FILTER = "message_type_id_filter"
 ATTR_INVOLVED_ENTITY_ID_FILTER = "involved_entity_id_filter"
 ATTR_REFERENCE_ID = "reference_id"
 ATTR_REFERENCE_TIME = "reference_time"
+ATTR_READER_ID = "reader_id"
+ATTR_DOOR_ID = "door_id"
+ATTR_CREDENTIAL_TEMPLATE = "credential_template"
+ATTR_CARD_NUMBER = "card_number"
+ATTR_PIN = "pin"
 
 REVIEW_CATEGORIES = ["System", "Audit", "Access", "Security", "Hardware"]
+
+BADGE_CREDENTIAL_SCHEMA = vol.Schema(
+    {
+        vol.Optional(ATTR_ENTRY_ID): cv.string,
+        vol.Required(ATTR_READER_ID): cv.string,
+        vol.Required(ATTR_CREDENTIAL_TEMPLATE): cv.string,
+        vol.Required(ATTR_CARD_NUMBER): cv.string,
+    }
+)
+
+SEND_PIN_SCHEMA = vol.Schema(
+    {
+        vol.Optional(ATTR_ENTRY_ID): cv.string,
+        vol.Required(ATTR_READER_ID): cv.string,
+        vol.Required(ATTR_PIN): cv.string,
+    }
+)
+
+GET_ATTACHED_READERS_SCHEMA = vol.Schema(
+    {
+        vol.Optional(ATTR_ENTRY_ID): cv.string,
+        vol.Required(ATTR_DOOR_ID): cv.string,
+    }
+)
 
 GET_REVIEW_EVENTS_SCHEMA = vol.Schema(
     {
@@ -92,6 +124,54 @@ def async_register_services(hass: HomeAssistant) -> None:
     if hass.services.has_service(DOMAIN, SERVICE_GET_REVIEW_EVENTS):
         return
 
+    async def async_badge_credential(call: ServiceCall) -> ServiceResponse:
+        """Virtually badge a credential at a door reader."""
+        coordinator = _resolve_coordinator(hass, call.data.get(ATTR_ENTRY_ID))
+
+        try:
+            activity_id = await coordinator.api.badge_credential_at_reader(
+                reader_id=call.data[ATTR_READER_ID],
+                credential_template=call.data[ATTR_CREDENTIAL_TEMPLATE],
+                card_number=call.data[ATTR_CARD_NUMBER],
+            )
+        except Exception as err:
+            LOGGER.exception("Failed to submit badge credential activity")
+            msg = f"Failed to submit badge credential activity: {err}"
+            raise HomeAssistantError(msg) from err
+
+        return {"activity_id": activity_id}
+
+    async def async_send_pin(call: ServiceCall) -> ServiceResponse:
+        """Virtually present a User PIN at a door reader."""
+        coordinator = _resolve_coordinator(hass, call.data.get(ATTR_ENTRY_ID))
+
+        try:
+            activity_id = await coordinator.api.send_pin_to_reader(
+                reader_id=call.data[ATTR_READER_ID],
+                pin=call.data[ATTR_PIN],
+            )
+        except Exception as err:
+            LOGGER.exception("Failed to submit PIN activity")
+            msg = f"Failed to submit PIN activity: {err}"
+            raise HomeAssistantError(msg) from err
+
+        return {"activity_id": activity_id}
+
+    async def async_get_attached_readers(call: ServiceCall) -> ServiceResponse:
+        """List readers attached to a door."""
+        coordinator = _resolve_coordinator(hass, call.data.get(ATTR_ENTRY_ID))
+
+        try:
+            readers = await coordinator.api.get_attached_readers(
+                door_id=call.data[ATTR_DOOR_ID],
+            )
+        except Exception as err:
+            LOGGER.exception("Failed to fetch attached readers")
+            msg = f"Failed to fetch attached readers: {err}"
+            raise HomeAssistantError(msg) from err
+
+        return {"readers": readers, "count": len(readers)}
+
     async def async_get_review_events(call: ServiceCall) -> ServiceResponse:
         """Query historical review events from the Inception controller."""
         coordinator = _resolve_coordinator(hass, call.data.get(ATTR_ENTRY_ID))
@@ -125,6 +205,27 @@ def async_register_services(hass: HomeAssistant) -> None:
         schema=GET_REVIEW_EVENTS_SCHEMA,
         supports_response=SupportsResponse.ONLY,
     )
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_BADGE_CREDENTIAL,
+        async_badge_credential,
+        schema=BADGE_CREDENTIAL_SCHEMA,
+        supports_response=SupportsResponse.OPTIONAL,
+    )
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_SEND_PIN,
+        async_send_pin,
+        schema=SEND_PIN_SCHEMA,
+        supports_response=SupportsResponse.OPTIONAL,
+    )
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_GET_ATTACHED_READERS,
+        async_get_attached_readers,
+        schema=GET_ATTACHED_READERS_SCHEMA,
+        supports_response=SupportsResponse.ONLY,
+    )
 
 
 @callback
@@ -133,3 +234,6 @@ def async_unregister_services(hass: HomeAssistant) -> None:
     if hass.data.get(DOMAIN):
         return
     hass.services.async_remove(DOMAIN, SERVICE_GET_REVIEW_EVENTS)
+    hass.services.async_remove(DOMAIN, SERVICE_BADGE_CREDENTIAL)
+    hass.services.async_remove(DOMAIN, SERVICE_SEND_PIN)
+    hass.services.async_remove(DOMAIN, SERVICE_GET_ATTACHED_READERS)

--- a/custom_components/inception/services.yaml
+++ b/custom_components/inception/services.yaml
@@ -29,6 +29,60 @@ area_arm:
       selector:
         text:
 
+badge_credential:
+  fields:
+    entry_id:
+      required: false
+      selector:
+        config_entry:
+          integration: inception
+    reader_id:
+      required: true
+      example: "5a1b8b27-3d0c-4d52-9f72-3f0e5b9d4a52"
+      selector:
+        text:
+    credential_template:
+      required: true
+      example: "0f8c5e94-5cb7-4f3f-9b66-2e2e3c0a5d33"
+      selector:
+        text:
+    card_number:
+      required: true
+      example: "0000123"
+      selector:
+        text:
+
+send_pin:
+  fields:
+    entry_id:
+      required: false
+      selector:
+        config_entry:
+          integration: inception
+    reader_id:
+      required: true
+      example: "5a1b8b27-3d0c-4d52-9f72-3f0e5b9d4a52"
+      selector:
+        text:
+    pin:
+      required: true
+      example: "1234"
+      selector:
+        text:
+
+get_attached_readers:
+  fields:
+    entry_id:
+      required: false
+      selector:
+        config_entry:
+          integration: inception
+    door_id:
+      required: true
+      example: "fbec7c22-500d-4f3b-b94e-4c19ff501f9f"
+      selector:
+        text:
+
 get_review_events:
   fields:
     entry_id:

--- a/custom_components/inception/translations/en.json
+++ b/custom_components/inception/translations/en.json
@@ -78,6 +78,60 @@
                 }
             }
         },
+        "badge_credential": {
+            "name": "Badge credential",
+            "description": "Virtually badges a user credential at a door reader, as though the card was physically presented. Returns the ActivityID of the submitted activity.",
+            "fields": {
+                "entry_id": {
+                    "name": "Inception hub",
+                    "description": "Select which configured Inception hub to target. Only required when multiple hubs are configured."
+                },
+                "reader_id": {
+                    "name": "Reader ID",
+                    "description": "ID of the reader to badge at. Discover reader IDs for a door via the 'Get attached readers' service."
+                },
+                "credential_template": {
+                    "name": "Credential template ID",
+                    "description": "The Credential Template ID of the user credential to badge."
+                },
+                "card_number": {
+                    "name": "Card number",
+                    "description": "The card number (Credential 'Data' value) of the user credential to badge."
+                }
+            }
+        },
+        "send_pin": {
+            "name": "Send PIN",
+            "description": "Virtually presents a User PIN at a door reader, as though it was physically entered. Returns the ActivityID of the submitted activity.",
+            "fields": {
+                "entry_id": {
+                    "name": "Inception hub",
+                    "description": "Select which configured Inception hub to target. Only required when multiple hubs are configured."
+                },
+                "reader_id": {
+                    "name": "Reader ID",
+                    "description": "ID of the reader to present the PIN at. Discover reader IDs for a door via the 'Get attached readers' service."
+                },
+                "pin": {
+                    "name": "PIN",
+                    "description": "The User PIN to present. PINs cannot be retrieved from the Inception API, so the caller must know the value."
+                }
+            }
+        },
+        "get_attached_readers": {
+            "name": "Get attached readers",
+            "description": "Returns the readers attached to a door. Use the resulting reader IDs with the 'Badge credential' and 'Send PIN' services.",
+            "fields": {
+                "entry_id": {
+                    "name": "Inception hub",
+                    "description": "Select which configured Inception hub to query. Only required when multiple hubs are configured."
+                },
+                "door_id": {
+                    "name": "Door ID",
+                    "description": "The ID of the door to list readers for."
+                }
+            }
+        },
         "get_review_events": {
             "name": "Get review events",
             "description": "Queries historical review events from the Inception controller. Returns matching events as a service response. All fields are optional; leave them empty to fetch the most recent events.",

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -99,17 +99,21 @@ attribute on the alarm panel entity.
 
 ## Tier 3 — opportunistic additions
 
-### 3.1 Virtual badge / virtual PIN services (idea)
+### 3.1 Virtual badge / virtual PIN services [x]
 
 [`activities.md`](inception-api/activities.md) — `POST /api/v1/activity`
 with `BadgeCredentialAtReader` or `SendPINDataToReader` lets HA "press
 the reader" on behalf of a user. Useful for "unlock door as Alice when
 her phone arrives".
 
-- **Shape**: two HA services (`inception.badge_credential`,
-  `inception.send_pin`) + reader discovery via
-  `GET /control/door/[id]/attached-readers`.
-- **Dependency**: User schema from 2.3.
+- **Delivered**: three HA services — `inception.badge_credential`,
+  `inception.send_pin`, and `inception.get_attached_readers` for reader
+  discovery via `GET /control/door/[id]/attached-readers`. Each service
+  returns the controller's `ActivityID` (or `null` on failure) for
+  optional follow-up via Activity Progress (see 2.2).
+- **Note**: the User schema from 2.3 wasn't actually required; callers
+  pass the credential template + card number directly, matching how the
+  Inception API exposes them.
 
 ### 3.2 Historical review-event query service (idea)
 

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -783,6 +783,124 @@ class TestBundledLongPoll:
         assert api_client._review_events_categories == []
 
 
+class TestVirtualActivityMethods:
+    """Tests for badge/PIN activity submission and reader discovery."""
+
+    @pytest.fixture
+    def mock_session(self) -> Mock:
+        """Create a mock session."""
+        return Mock(spec=aiohttp.ClientSession)
+
+    @pytest.mark.asyncio
+    async def test_get_attached_readers_returns_list(self, mock_session: Mock) -> None:
+        """A list response from /attached-readers is returned verbatim."""
+        api_client = InceptionApiClient(
+            token="t", host="http://h.test", session=mock_session
+        )
+        readers = [{"ID": "reader-1"}, {"ID": "reader-2"}]
+        with patch.object(api_client, "request", return_value=readers) as mock_request:
+            result = await api_client.get_attached_readers("door-1")
+
+        assert result == readers
+        mock_request.assert_awaited_once_with(
+            method="get",
+            path="/control/door/door-1/attached-readers",
+        )
+
+    @pytest.mark.asyncio
+    async def test_get_attached_readers_non_list_returns_empty(
+        self, mock_session: Mock
+    ) -> None:
+        """A non-list response is normalised to an empty list."""
+        api_client = InceptionApiClient(
+            token="t", host="http://h.test", session=mock_session
+        )
+        with patch.object(api_client, "request", return_value={"unexpected": "shape"}):
+            result = await api_client.get_attached_readers("door-1")
+
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_badge_credential_at_reader_returns_activity_id(
+        self, mock_session: Mock
+    ) -> None:
+        """A Success response yields the ActivityID."""
+        api_client = InceptionApiClient(
+            token="t", host="http://h.test", session=mock_session
+        )
+        response = {
+            "Response": {"Result": "Success", "Message": "OK"},
+            "ActivityID": "act-1",
+        }
+        with patch.object(api_client, "request", return_value=response) as mock_request:
+            activity_id = await api_client.badge_credential_at_reader(
+                reader_id="reader-1",
+                credential_template="template-1",
+                card_number="0000123",
+            )
+
+        assert activity_id == "act-1"
+        mock_request.assert_awaited_once_with(
+            method="post",
+            path="/activity",
+            data={
+                "Type": "BadgeCredentialAtReader",
+                "CredentialData": {
+                    "CredentialTemplate": "template-1",
+                    "Data": "0000123",
+                },
+                "Entity": "reader-1",
+            },
+        )
+
+    @pytest.mark.asyncio
+    async def test_send_pin_to_reader_returns_activity_id(
+        self, mock_session: Mock
+    ) -> None:
+        """A Success response yields the ActivityID."""
+        api_client = InceptionApiClient(
+            token="t", host="http://h.test", session=mock_session
+        )
+        response = {
+            "Response": {"Result": "Success", "Message": "OK"},
+            "ActivityID": "act-2",
+        }
+        with patch.object(api_client, "request", return_value=response) as mock_request:
+            activity_id = await api_client.send_pin_to_reader(
+                reader_id="reader-1", pin="1234"
+            )
+
+        assert activity_id == "act-2"
+        mock_request.assert_awaited_once_with(
+            method="post",
+            path="/activity",
+            data={
+                "Type": "SendPINDataToReader",
+                "Entity": "reader-1",
+                "PINData": "1234",
+            },
+        )
+
+    @pytest.mark.asyncio
+    async def test_failure_response_raises(self, mock_session: Mock) -> None:
+        """A Failure response raises InceptionApiClientError with the message."""
+        api_client = InceptionApiClient(
+            token="t", host="http://h.test", session=mock_session
+        )
+        response = {
+            "Response": {"Result": "Failure", "Message": "Unknown reader"},
+        }
+        with (
+            patch.object(api_client, "request", return_value=response),
+            pytest.raises(InceptionApiClientError, match="Unknown reader"),
+        ):
+            await api_client.badge_credential_at_reader(
+                reader_id="reader-1",
+                credential_template="template-1",
+                card_number="0000123",
+            )
+
+
 class TestGetReviewEvents:
     """Test the get_review_events query helper."""
 

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -10,10 +10,22 @@ from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 
 from custom_components.inception.const import DOMAIN
 from custom_components.inception.services import (
+    SERVICE_BADGE_CREDENTIAL,
+    SERVICE_GET_ATTACHED_READERS,
     SERVICE_GET_REVIEW_EVENTS,
+    SERVICE_SEND_PIN,
     _resolve_coordinator,
     async_register_services,
 )
+
+
+def _registered_handler(hass: MagicMock, service_name: str) -> Any:
+    """Return the handler that was registered under ``service_name``."""
+    for call_args in hass.services.async_register.call_args_list:
+        if call_args.args[1] == service_name:
+            return call_args.args[2]
+    msg = f"Service {service_name} not registered"
+    raise AssertionError(msg)
 
 
 def _hass_with_coordinators(coordinators: dict[str, Any]) -> MagicMock:
@@ -63,15 +75,19 @@ class TestResolveCoordinator:
 class TestAsyncRegisterServices:
     """Test the service registration entry point."""
 
-    def test_registers_get_review_events_once(self) -> None:
-        """async_register_services registers the get_review_events service."""
+    def test_registers_all_services(self) -> None:
+        """async_register_services registers every Inception domain service."""
         hass = _hass_with_coordinators({"a": MagicMock()})
         async_register_services(hass)
 
-        hass.services.async_register.assert_called_once()
-        call_args = hass.services.async_register.call_args
-        assert call_args.args[0] == DOMAIN
-        assert call_args.args[1] == SERVICE_GET_REVIEW_EVENTS
+        registered = [
+            call_args.args[1]
+            for call_args in hass.services.async_register.call_args_list
+        ]
+        assert SERVICE_GET_REVIEW_EVENTS in registered
+        assert SERVICE_BADGE_CREDENTIAL in registered
+        assert SERVICE_SEND_PIN in registered
+        assert SERVICE_GET_ATTACHED_READERS in registered
 
     def test_skips_when_already_registered(self) -> None:
         """Re-invocation is a no-op so multiple entries don't double-register."""
@@ -92,7 +108,7 @@ class TestAsyncRegisterServices:
         hass = _hass_with_coordinators({"only": coordinator})
 
         async_register_services(hass)
-        handler = hass.services.async_register.call_args.args[2]
+        handler = _registered_handler(hass, SERVICE_GET_REVIEW_EVENTS)
 
         call = MagicMock()
         call.data = {
@@ -128,10 +144,152 @@ class TestAsyncRegisterServices:
         hass = _hass_with_coordinators({"only": coordinator})
 
         async_register_services(hass)
-        handler = hass.services.async_register.call_args.args[2]
+        handler = _registered_handler(hass, SERVICE_GET_REVIEW_EVENTS)
 
         call = MagicMock()
         call.data = {}
+
+        with pytest.raises(HomeAssistantError):
+            await handler(call)
+
+
+class TestBadgeCredentialService:
+    """Tests for the inception.badge_credential service handler."""
+
+    @pytest.mark.asyncio
+    async def test_handler_delegates_to_api(self) -> None:
+        """Required fields are forwarded to badge_credential_at_reader."""
+        coordinator = MagicMock()
+        coordinator.api.badge_credential_at_reader = AsyncMock(
+            return_value="activity-1"
+        )
+        hass = _hass_with_coordinators({"only": coordinator})
+
+        async_register_services(hass)
+        handler = _registered_handler(hass, SERVICE_BADGE_CREDENTIAL)
+
+        call = MagicMock()
+        call.data = {
+            "reader_id": "reader-1",
+            "credential_template": "template-1",
+            "card_number": "0000123",
+        }
+
+        response = await handler(call)
+
+        coordinator.api.badge_credential_at_reader.assert_awaited_once_with(
+            reader_id="reader-1",
+            credential_template="template-1",
+            card_number="0000123",
+        )
+        assert response == {"activity_id": "activity-1"}
+
+    @pytest.mark.asyncio
+    async def test_handler_wraps_api_errors(self) -> None:
+        """API failures surface as HomeAssistantError."""
+        coordinator = MagicMock()
+        coordinator.api.badge_credential_at_reader = AsyncMock(
+            side_effect=RuntimeError("boom")
+        )
+        hass = _hass_with_coordinators({"only": coordinator})
+
+        async_register_services(hass)
+        handler = _registered_handler(hass, SERVICE_BADGE_CREDENTIAL)
+
+        call = MagicMock()
+        call.data = {
+            "reader_id": "reader-1",
+            "credential_template": "template-1",
+            "card_number": "0000123",
+        }
+
+        with pytest.raises(HomeAssistantError):
+            await handler(call)
+
+
+class TestSendPinService:
+    """Tests for the inception.send_pin service handler."""
+
+    @pytest.mark.asyncio
+    async def test_handler_delegates_to_api(self) -> None:
+        """Required fields are forwarded to send_pin_to_reader."""
+        coordinator = MagicMock()
+        coordinator.api.send_pin_to_reader = AsyncMock(return_value="activity-2")
+        hass = _hass_with_coordinators({"only": coordinator})
+
+        async_register_services(hass)
+        handler = _registered_handler(hass, SERVICE_SEND_PIN)
+
+        call = MagicMock()
+        call.data = {"reader_id": "reader-1", "pin": "1234"}
+
+        response = await handler(call)
+
+        coordinator.api.send_pin_to_reader.assert_awaited_once_with(
+            reader_id="reader-1",
+            pin="1234",
+        )
+        assert response == {"activity_id": "activity-2"}
+
+    @pytest.mark.asyncio
+    async def test_handler_wraps_api_errors(self) -> None:
+        """API failures surface as HomeAssistantError."""
+        coordinator = MagicMock()
+        coordinator.api.send_pin_to_reader = AsyncMock(side_effect=RuntimeError("boom"))
+        hass = _hass_with_coordinators({"only": coordinator})
+
+        async_register_services(hass)
+        handler = _registered_handler(hass, SERVICE_SEND_PIN)
+
+        call = MagicMock()
+        call.data = {"reader_id": "reader-1", "pin": "1234"}
+
+        with pytest.raises(HomeAssistantError):
+            await handler(call)
+
+
+class TestGetAttachedReadersService:
+    """Tests for the inception.get_attached_readers service handler."""
+
+    @pytest.mark.asyncio
+    async def test_handler_returns_readers(self) -> None:
+        """Door ID is forwarded and the reader list is returned with a count."""
+        coordinator = MagicMock()
+        coordinator.api.get_attached_readers = AsyncMock(
+            return_value=[{"ID": "reader-1"}, {"ID": "reader-2"}]
+        )
+        hass = _hass_with_coordinators({"only": coordinator})
+
+        async_register_services(hass)
+        handler = _registered_handler(hass, SERVICE_GET_ATTACHED_READERS)
+
+        call = MagicMock()
+        call.data = {"door_id": "door-1"}
+
+        response = await handler(call)
+
+        coordinator.api.get_attached_readers.assert_awaited_once_with(
+            door_id="door-1",
+        )
+        assert response == {
+            "readers": [{"ID": "reader-1"}, {"ID": "reader-2"}],
+            "count": 2,
+        }
+
+    @pytest.mark.asyncio
+    async def test_handler_wraps_api_errors(self) -> None:
+        """API failures surface as HomeAssistantError."""
+        coordinator = MagicMock()
+        coordinator.api.get_attached_readers = AsyncMock(
+            side_effect=RuntimeError("boom")
+        )
+        hass = _hass_with_coordinators({"only": coordinator})
+
+        async_register_services(hass)
+        handler = _registered_handler(hass, SERVICE_GET_ATTACHED_READERS)
+
+        call = MagicMock()
+        call.data = {"door_id": "door-1"}
 
         with pytest.raises(HomeAssistantError):
             await handler(call)


### PR DESCRIPTION
## Summary

Delivers roadmap item 3.1 — virtual badge / virtual PIN services backed by Inception's `POST /api/v1/activity` endpoint, plus the reader-discovery endpoint that callers need to find a `reader_id`.

- `inception.badge_credential` — virtually badge a card at a reader (`BadgeCredentialAtReader`)
- `inception.send_pin` — virtually present a User PIN at a reader (`SendPINDataToReader`)
- `inception.get_attached_readers` — list readers attached to a door

Each activity service returns the controller's `ActivityID` for optional follow-up via Activity Progress monitoring (roadmap 2.2). When the controller returns a `Failure` envelope, the API layer raises `InceptionApiClientError` carrying the controller's message, which the service handlers map to `HomeAssistantError` so the failure surfaces in the UI / scripts.

The User-schema dependency the roadmap noted from 2.3 turned out to be unnecessary — callers supply `credential_template` + `card_number` directly, matching how the Inception API exposes them on `User.PhysicalCredentials[]`.

## Test plan

- [x] `scripts/lint` clean
- [x] `scripts/tests` — 215 unit tests pass, including new coverage in `tests/unit/test_api.py` and `tests/unit/test_services.py`
- [x] Smoke-test against a live controller / SkyTunnel sample:
  - [x] Call `inception.get_attached_readers` for a known door, confirm the reader list matches the web UI
  - [x] Call `inception.badge_credential` with a real credential, confirm the door grants access and the returned `ActivityID` shows up in the review log
  - [x] Call `inception.send_pin` with a known user PIN, confirm the access attempt is attributed correctly
  - [ ] Trigger a failure (bad reader ID) and confirm the service raises `HomeAssistantError` with the controller's message