### PR TITLE
Add binary sensors for configured time periods

### DIFF
--- a/custom_components/inception/binary_sensor.py
+++ b/custom_components/inception/binary_sensor.py
@@ -17,6 +17,7 @@ from .const import DOMAIN, MANUFACTURER
 from .entity import InceptionEntity, panel_identifiers
 from .pyinception.schemas.door import DoorPublicState
 from .pyinception.schemas.input import InputPublicState
+from .pyinception.schemas.time_period import TimePeriodPublicState
 from .util import find_matching_door
 
 if TYPE_CHECKING:
@@ -32,6 +33,7 @@ if TYPE_CHECKING:
         InceptionSummaryEntry,
     )
     from .pyinception.schemas.input import InputSummaryEntry
+    from .pyinception.schemas.time_period import TimePeriodSummaryEntry
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -249,6 +251,29 @@ async def async_setup_entry(
                 )
             )
 
+    # Create time period binary sensors. Time Periods are Inception's
+    # scheduling primitive (e.g. "Business Hours" or "Weekend"); each one is
+    # either active or inactive at any given moment. One binary sensor is
+    # created per configured time period, reporting whether it is currently
+    # active. Controllers whose firmware does not expose time periods simply
+    # yield an empty list here.
+    entities.extend(
+        InceptionTimePeriodBinarySensor(
+            coordinator=coordinator,
+            entity_description=InceptionBinarySensorDescription(
+                key="time_period",
+                icon="mdi:calendar-clock",
+                has_entity_name=True,
+                value_fn=lambda data: (
+                    data.public_state is not None
+                    and bool(data.public_state & TimePeriodPublicState.ACTIVE)
+                ),
+            ),
+            data=time_period,
+        )
+        for time_period in coordinator.data.time_periods.get_items()
+    )
+
     async_add_entities(entities)
 
 
@@ -345,3 +370,40 @@ class InceptionDoorBinarySensor(
             manufacturer=MANUFACTURER,
             via_device=panel_identifiers(coordinator),
         )
+
+
+class InceptionTimePeriodBinarySensor(
+    InceptionBinarySensor,
+):
+    """inception binary_sensor for Time Periods."""
+
+    data: TimePeriodSummaryEntry
+
+    def __init__(
+        self,
+        coordinator: InceptionUpdateCoordinator,
+        entity_description: InceptionBinarySensorDescription,
+        data: TimePeriodSummaryEntry,
+    ) -> None:
+        """Initialize the binary_sensor class."""
+        super().__init__(coordinator, entity_description=entity_description, data=data)
+
+        self.data = data
+        self._device_id = data.entity_info.id
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, self._device_id)},
+            name=data.entity_info.name,
+            manufacturer=MANUFACTURER,
+            via_device=panel_identifiers(coordinator),
+        )
+
+    @property
+    def name(self) -> str | None:
+        """
+        Return None so the entity inherits its device (time period) name.
+
+        A time period maps to exactly one binary sensor, so it is the primary
+        feature of its device — Home Assistant then labels it with the time
+        period's name (e.g. "Business Hours") rather than a redundant suffix.
+        """
+        return None

--- a/custom_components/inception/diagnostics.py
+++ b/custom_components/inception/diagnostics.py
@@ -77,5 +77,6 @@ async def async_get_config_entry_diagnostics(
             "doors": _summary_to_dict(getattr(api_data, "doors", None)),
             "areas": _summary_to_dict(getattr(api_data, "areas", None)),
             "outputs": _summary_to_dict(getattr(api_data, "outputs", None)),
+            "time_periods": _summary_to_dict(getattr(api_data, "time_periods", None)),
         },
     }

--- a/custom_components/inception/pyinception/api.py
+++ b/custom_components/inception/pyinception/api.py
@@ -18,6 +18,7 @@ from .schemas.input import InputPublicState, InputSummary
 from .schemas.output import OutputPublicState, OutputSummary
 from .schemas.review_events import LiveReviewEventsRequest
 from .schemas.system_info import SystemInfo
+from .schemas.time_period import TimePeriodPublicState, TimePeriodSummary
 from .schemas.update_monitor import (
     MonitorEntityStatesRequest,
     UpdateMonitorResponse,
@@ -80,7 +81,9 @@ class InceptionApiClient:
         self.protocol_version: int | None = None
         self.system_info: SystemInfo | None = None
 
-    T = TypeVar("T", DoorSummary, InputSummary, OutputSummary, AreaSummary)
+    T = TypeVar(
+        "T", DoorSummary, InputSummary, OutputSummary, AreaSummary, TimePeriodSummary
+    )
 
     async def get_controls(self, Type: type[T]) -> T:  # noqa: N803
         """Get control item summaries."""
@@ -89,6 +92,7 @@ class InceptionApiClient:
             InputSummary: "input",
             OutputSummary: "output",
             AreaSummary: "area",
+            TimePeriodSummary: "time-period",
         }
         if Type not in path_map:
             msg = f"Unsupported entity type: {Type}"
@@ -182,11 +186,12 @@ class InceptionApiClient:
     async def get_data(self) -> InceptionApiData:
         """Get the status of the API."""
         if self.data is None:
-            doors, outputs, inputs, areas = await asyncio.gather(
+            doors, outputs, inputs, areas, time_periods = await asyncio.gather(
                 self.get_controls(DoorSummary),
                 self.get_controls(OutputSummary),
                 self.get_controls(InputSummary),
                 self.get_controls(AreaSummary),
+                self._get_time_periods(),
             )
 
             self.data = InceptionApiData(
@@ -194,9 +199,29 @@ class InceptionApiClient:
                 doors=doors,
                 areas=areas,
                 outputs=outputs,
+                time_periods=time_periods,
             )
 
         return self.data
+
+    async def _get_time_periods(self) -> TimePeriodSummary:
+        """
+        Fetch the time-period summary, tolerating controllers that lack it.
+
+        Time Periods follow the same universal `/control/[type]/summary`
+        convention as the other entity types, but the endpoint is only present
+        on firmware that supports it. Any non-auth failure (e.g. a 404 on older
+        firmware) degrades to an empty summary so the core entity types keep
+        working. Authentication errors are re-raised so the coordinator can
+        route them into Home Assistant's re-auth flow.
+        """
+        try:
+            return await self.get_controls(TimePeriodSummary)
+        except InceptionApiClientAuthenticationError:
+            raise
+        except Exception as err:  # noqa: BLE001
+            _LOGGER.debug("Time periods not available: %s", err)
+            return TimePeriodSummary(TimePeriods={})
 
     REVIEW_EVENTS_REQUEST_ID: ClassVar[str] = "LiveReviewEventsRequest"
 
@@ -204,8 +229,9 @@ class InceptionApiClient:
         """
         Run a single long-poll iteration against `/monitor-updates`.
 
-        The payload bundles state-change sub-requests for all four entity
-        types (Input, Door, Output, Area), plus the LiveReviewEvents
+        The payload bundles state-change sub-requests for the four core entity
+        types (Input, Door, Output, Area) — plus a Time Period sub-request when
+        the controller exposes time periods, and the LiveReviewEvents
         sub-request when review events are enabled. The server returns a
         response for exactly one sub-request per call (matched by `ID`),
         so the dispatch here simply routes on the response `ID`.
@@ -215,6 +241,28 @@ class InceptionApiClient:
             _LOGGER.warning("state monitor: no data to update")
             return
 
+        entity_state_specs = [
+            ("InputStateRequest", "InputState", InputPublicState, "inputs"),
+            ("DoorStateRequest", "DoorState", DoorPublicState, "doors"),
+            ("OutputStateRequest", "OutputState", OutputPublicState, "outputs"),
+            ("AreaStateRequest", "AreaState", AreaPublicState, "areas"),
+        ]
+
+        # Only monitor time-period state on controllers that actually expose
+        # time periods (i.e. the /control/time-period/summary fetch returned
+        # items). This avoids sending an unrecognised `TimePeriodState`
+        # sub-request to firmware that doesn't support it, which could disrupt
+        # the shared long-poll for the other entity types.
+        if self.data.time_periods.get_items():
+            entity_state_specs.append(
+                (
+                    "TimePeriodStateRequest",
+                    "TimePeriodState",
+                    TimePeriodPublicState,
+                    "time_periods",
+                )
+            )
+
         request_types = {
             request_id: MonitorEntityStatesRequest(
                 request_id=request_id,
@@ -223,12 +271,12 @@ class InceptionApiClient:
                 time_since_last_update=self._monitor_update_times.get(request_id, 0),
                 api_data=api_data,
             )
-            for request_id, state_type, public_state_type, api_data in [
-                ("InputStateRequest", "InputState", InputPublicState, "inputs"),
-                ("DoorStateRequest", "DoorState", DoorPublicState, "doors"),
-                ("OutputStateRequest", "OutputState", OutputPublicState, "outputs"),
-                ("AreaStateRequest", "AreaState", AreaPublicState, "areas"),
-            ]
+            for (
+                request_id,
+                state_type,
+                public_state_type,
+                api_data,
+            ) in entity_state_specs
         }
 
         payload = [

--- a/custom_components/inception/pyinception/data.py
+++ b/custom_components/inception/pyinception/data.py
@@ -1,11 +1,12 @@
 """Contains data classes for the Inception API."""
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from .schemas.area import AreaSummary
 from .schemas.door import DoorSummary
 from .schemas.input import InputSummary
 from .schemas.output import OutputSummary
+from .schemas.time_period import TimePeriodSummary
 
 
 @dataclass
@@ -16,3 +17,9 @@ class InceptionApiData:
     doors: DoorSummary
     areas: AreaSummary
     outputs: OutputSummary
+    # Time periods are only present on controllers whose firmware exposes the
+    # `/control/time-period/summary` endpoint; default to an empty summary so
+    # the other entity types keep working when it is absent.
+    time_periods: TimePeriodSummary = field(
+        default_factory=lambda: TimePeriodSummary(TimePeriods={})
+    )

--- a/custom_components/inception/pyinception/schemas/time_period.py
+++ b/custom_components/inception/pyinception/schemas/time_period.py
@@ -1,0 +1,63 @@
+# ruff: noqa: ANN003
+
+"""Inception Time Period schemas."""
+
+from dataclasses import dataclass
+
+from .entities import (
+    InceptionPublicState,
+    InceptionSummary,
+    InceptionSummaryEntry,
+    ReportableShortEntity,
+)
+
+
+class TimePeriodPublicState(InceptionPublicState):
+    """
+    Time Period public states.
+
+    A Time Period is Inception's scheduling primitive (e.g. "Business Hours").
+    At any moment it is either active or inactive; the ``ACTIVE`` bit is the
+    one that matters for a binary sensor. The flag values mirror the Output
+    schema's active/inactive convention.
+    """
+
+    ACTIVE = 0x001
+    INACTIVE = 0x002
+
+    @staticmethod
+    def get_state_description(state_value: int) -> list[str]:
+        """Get the list of state descriptions for the given state value."""
+        descriptions = {
+            TimePeriodPublicState.ACTIVE: "Time period is currently active",
+            TimePeriodPublicState.INACTIVE: "Time period is currently inactive",
+        }
+
+        return [
+            descriptions[state]
+            for state in TimePeriodPublicState
+            if state_value & state
+        ]
+
+
+@dataclass
+class TimePeriodSummaryEntry(InceptionSummaryEntry[TimePeriodPublicState]):
+    """Represents a summary entry for a time period."""
+
+    def __init__(self, **kwargs) -> None:
+        """Initialize the object."""
+        self.entity_info = ReportableShortEntity(**kwargs.pop("EntityInfo"))
+        super().__init__(**kwargs)
+
+
+@dataclass
+class TimePeriodSummary(InceptionSummary[TimePeriodSummaryEntry]):
+    """Represents a summary of time periods."""
+
+    def __init__(self, **kwargs) -> None:
+        """Initialize the object."""
+        self.items = {
+            time_period_id: TimePeriodSummaryEntry(**data)
+            for time_period_id, data in kwargs.pop("TimePeriods").items()
+        }
+        super().__init__(**kwargs)

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -545,6 +545,81 @@ class TestProtocolVersion:
         assert version is None
 
 
+class TestGetTimePeriods:
+    """Tests for the defensive time-period fetch."""
+
+    @pytest.fixture
+    def mock_session(self) -> Mock:
+        """Return a mocked aiohttp session."""
+        return Mock(spec=aiohttp.ClientSession)
+
+    @pytest.mark.asyncio
+    async def test_returns_summary_on_success(self, mock_session: Mock) -> None:
+        """A well-formed summary response is parsed into time period items."""
+        api_client = InceptionApiClient(
+            token="t", host="http://h.test", session=mock_session
+        )
+        summary_payload = {
+            "TimePeriods": {
+                "tp_1": {
+                    "EntityInfo": {
+                        "ID": "tp_1",
+                        "Name": "Business Hours",
+                        "ReportingID": "1",
+                    },
+                    "CurrentState": 1,
+                }
+            }
+        }
+        with patch.object(
+            api_client, "request", return_value=summary_payload
+        ) as mock_request:
+            summary = await api_client._get_time_periods()
+
+        items = summary.get_items()
+        assert len(items) == 1
+        assert items[0].entity_info.name == "Business Hours"
+        mock_request.assert_awaited_once_with(
+            method="get",
+            path="/control/time-period/summary",
+        )
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_on_404(self, mock_session: Mock) -> None:
+        """Firmware without time periods (404) degrades to an empty summary."""
+        api_client = InceptionApiClient(
+            token="t", host="http://h.test", session=mock_session
+        )
+        with patch.object(
+            api_client,
+            "request",
+            side_effect=InceptionApiClientCommunicationError(
+                "Error fetching information - 404, message='Not Found'"
+            ),
+        ):
+            summary = await api_client._get_time_periods()
+
+        assert summary.get_items() == []
+
+    @pytest.mark.asyncio
+    async def test_reraises_auth_error(self, mock_session: Mock) -> None:
+        """Authentication errors propagate so re-auth can be triggered."""
+        api_client = InceptionApiClient(
+            token="t", host="http://h.test", session=mock_session
+        )
+        with (
+            patch.object(
+                api_client,
+                "request",
+                side_effect=InceptionApiClientAuthenticationError(
+                    "Invalid credentials"
+                ),
+            ),
+            pytest.raises(InceptionApiClientAuthenticationError),
+        ):
+            await api_client._get_time_periods()
+
+
 class TestRequestApiPrefix:
     """Tests for the api_prefix argument to request()."""
 
@@ -627,6 +702,8 @@ class TestBundledLongPoll:
             token="t", host="http://h.test", session=mock_session
         )
         api_client.data = Mock()
+        # No time periods configured -> no TimePeriod sub-request bundled.
+        api_client.data.time_periods.get_items.return_value = []
         api_client._review_events_enabled = False
 
         captured_payloads: list[list[dict[str, Any]]] = []
@@ -657,6 +734,8 @@ class TestBundledLongPoll:
             token="t", host="http://h.test", session=mock_session
         )
         api_client.data = Mock()
+        # No time periods configured -> no TimePeriod sub-request bundled.
+        api_client.data.time_periods.get_items.return_value = []
         api_client._review_events_enabled = True
         api_client._review_events_categories = ["Access", "Security"]
 
@@ -678,6 +757,44 @@ class TestBundledLongPoll:
         ids = [entry["ID"] for entry in captured_payloads[0]]
         assert InceptionApiClient.REVIEW_EVENTS_REQUEST_ID in ids
         assert len(ids) == 5
+
+    @pytest.mark.asyncio
+    async def test_payload_includes_time_period_request_when_present(
+        self, mock_session: Mock
+    ) -> None:
+        """A TimePeriodState sub-request is bundled when time periods exist."""
+        api_client = InceptionApiClient(
+            token="t", host="http://h.test", session=mock_session
+        )
+        api_client.data = Mock()
+        # At least one time period configured -> bundle the sub-request.
+        api_client.data.time_periods.get_items.return_value = [Mock()]
+        api_client._review_events_enabled = False
+
+        captured_payloads: list[list[dict[str, Any]]] = []
+
+        async def fake_request(payload: list[dict[str, Any]]) -> None:
+            captured_payloads.append(payload)
+
+        with patch.object(
+            api_client, "_monitor_events_request", side_effect=fake_request
+        ):
+            await api_client.monitor_entity_states()
+
+        assert len(captured_payloads) == 1
+        payload = captured_payloads[0]
+        ids = [entry["ID"] for entry in payload]
+        assert ids == [
+            "InputStateRequest",
+            "DoorStateRequest",
+            "OutputStateRequest",
+            "AreaStateRequest",
+            "TimePeriodStateRequest",
+        ]
+        tp_entry = next(
+            entry for entry in payload if entry["ID"] == "TimePeriodStateRequest"
+        )
+        assert tp_entry["InputData"]["stateType"] == "TimePeriodState"
 
     @pytest.mark.asyncio
     async def test_review_events_response_routed_to_processor(

--- a/tests/unit/test_binary_sensor.py
+++ b/tests/unit/test_binary_sensor.py
@@ -8,12 +8,17 @@ from homeassistant.components.binary_sensor import BinarySensorDeviceClass
 from homeassistant.helpers.entity import Entity
 
 from custom_components.inception.binary_sensor import (
+    InceptionTimePeriodBinarySensor,
     async_setup_entry,
     get_device_class_for_name,
 )
 from custom_components.inception.coordinator import InceptionUpdateCoordinator
 from custom_components.inception.pyinception.schemas.door import DoorPublicState
 from custom_components.inception.pyinception.schemas.input import InputPublicState
+from custom_components.inception.pyinception.schemas.time_period import (
+    TimePeriodPublicState,
+    TimePeriodSummary,
+)
 
 
 class TestBinarySensorKeys:
@@ -36,6 +41,9 @@ class TestBinarySensorKeys:
         coordinator.data = Mock()
         coordinator.data.inputs = Mock()
         coordinator.data.inputs.get_items = Mock(return_value=[])
+        # Default to no time periods; individual tests override as needed.
+        coordinator.data.time_periods = Mock()
+        coordinator.data.time_periods.get_items = Mock(return_value=[])
 
         return coordinator
 
@@ -537,6 +545,155 @@ class TestBinarySensorKeys:
             "identifiers"
         ]  # pyright: ignore[reportTypedDictNotRequiredAccess]
         assert input_sensor._attr_device_info["name"] == "PIR Motion Sensor"  # pyright: ignore[reportTypedDictNotRequiredAccess]
+
+
+def _build_time_period_summary(
+    periods: list[tuple[str, str, str, int]],
+) -> TimePeriodSummary:
+    """Build a real TimePeriodSummary from (id, name, reporting_id, state) tuples."""
+    return TimePeriodSummary(
+        TimePeriods={
+            tp_id: {
+                "EntityInfo": {"ID": tp_id, "Name": name, "ReportingID": reporting_id},
+                "CurrentState": state,
+            }
+            for tp_id, name, reporting_id, state in periods
+        }
+    )
+
+
+class TestTimePeriodBinarySensor:
+    """Test time period binary sensors."""
+
+    @pytest.fixture
+    def mock_coordinator(self) -> Mock:
+        """Create a mock coordinator with empty doors/inputs by default."""
+        coordinator = Mock(spec=InceptionUpdateCoordinator)
+        coordinator.config_entry = Mock()
+        coordinator.config_entry.entry_id = "test_entry_id"
+        coordinator.api = Mock()
+        coordinator.api._host = "test.example.com"
+
+        coordinator.data = Mock()
+        coordinator.data.doors = Mock()
+        coordinator.data.doors.get_items = Mock(return_value=[])
+        coordinator.data.inputs = Mock()
+        coordinator.data.inputs.get_items = Mock(return_value=[])
+        coordinator.data.time_periods = Mock()
+        coordinator.data.time_periods.get_items = Mock(return_value=[])
+
+        return coordinator
+
+    @pytest.fixture
+    def mock_hass(self) -> Mock:
+        """Create a mock Home Assistant instance."""
+        hass = Mock()
+        hass.data = {}
+        return hass
+
+    @pytest.fixture
+    def mock_entry(self) -> Mock:
+        """Create a mock config entry."""
+        entry = Mock()
+        entry.entry_id = "test_entry_id"
+        return entry
+
+    async def _setup(
+        self, mock_coordinator: Mock, mock_hass: Mock, mock_entry: Mock
+    ) -> list[Entity]:
+        """Run async_setup_entry and return the created entities."""
+        added_entities: list[Entity] = []
+
+        def mock_async_add_entities(
+            new_entities: Iterable[Entity],
+            update_before_add: bool = False,  # noqa: FBT001, FBT002, ARG001
+        ) -> None:
+            added_entities.extend(new_entities)
+
+        mock_hass.data = {"inception": {mock_entry.entry_id: mock_coordinator}}
+        await async_setup_entry(mock_hass, mock_entry, mock_async_add_entities)
+        return added_entities
+
+    @pytest.mark.asyncio
+    async def test_creates_one_sensor_per_time_period(
+        self, mock_coordinator: Mock, mock_hass: Mock, mock_entry: Mock
+    ) -> None:
+        """Each configured time period yields exactly one binary sensor."""
+        summary = _build_time_period_summary(
+            [
+                ("tp_1", "Business Hours", "1", TimePeriodPublicState.ACTIVE),
+                ("tp_2", "Weekend", "2", TimePeriodPublicState.INACTIVE),
+            ]
+        )
+        mock_coordinator.data.time_periods.get_items = Mock(
+            return_value=summary.get_items()
+        )
+
+        added_entities = await self._setup(mock_coordinator, mock_hass, mock_entry)
+
+        time_period_sensors = [
+            e for e in added_entities if isinstance(e, InceptionTimePeriodBinarySensor)
+        ]
+        assert len(time_period_sensors) == 2
+        assert len(added_entities) == 2
+
+        keys = sorted(e._attr_unique_id for e in time_period_sensors)
+        assert keys == ["tp_1_time_period", "tp_2_time_period"]
+
+    @pytest.mark.asyncio
+    async def test_is_on_reflects_active_state(
+        self, mock_coordinator: Mock, mock_hass: Mock, mock_entry: Mock
+    ) -> None:
+        """is_on is True only for the active time period."""
+        summary = _build_time_period_summary(
+            [
+                ("tp_active", "Business Hours", "1", TimePeriodPublicState.ACTIVE),
+                ("tp_inactive", "Weekend", "2", TimePeriodPublicState.INACTIVE),
+            ]
+        )
+        mock_coordinator.data.time_periods.get_items = Mock(
+            return_value=summary.get_items()
+        )
+
+        added_entities = await self._setup(mock_coordinator, mock_hass, mock_entry)
+
+        by_id = {e._attr_unique_id: e for e in added_entities}
+        assert by_id["tp_active_time_period"].is_on is True
+        assert by_id["tp_inactive_time_period"].is_on is False
+
+    @pytest.mark.asyncio
+    async def test_time_period_device_grouping_and_name(
+        self, mock_coordinator: Mock, mock_hass: Mock, mock_entry: Mock
+    ) -> None:
+        """A time period sensor is its own device under the panel, named after it."""
+        summary = _build_time_period_summary(
+            [("tp_1", "Business Hours", "1", TimePeriodPublicState.ACTIVE)]
+        )
+        mock_coordinator.data.time_periods.get_items = Mock(
+            return_value=summary.get_items()
+        )
+
+        added_entities = await self._setup(mock_coordinator, mock_hass, mock_entry)
+
+        assert len(added_entities) == 1
+        sensor = added_entities[0]
+
+        # Its own device, grouped under the panel via_device.
+        assert sensor._attr_device_info is not None
+        assert ("inception", "tp_1") in sensor._attr_device_info["identifiers"]  # pyright: ignore[reportTypedDictNotRequiredAccess]
+        assert sensor._attr_device_info["name"] == "Business Hours"  # pyright: ignore[reportTypedDictNotRequiredAccess]
+
+        # Primary feature of the device: name is None so HA uses the device name.
+        assert sensor.name is None
+        assert sensor.entity_description.icon == "mdi:calendar-clock"
+
+    @pytest.mark.asyncio
+    async def test_no_time_periods_creates_no_sensors(
+        self, mock_coordinator: Mock, mock_hass: Mock, mock_entry: Mock
+    ) -> None:
+        """A controller without time periods creates no time period sensors."""
+        added_entities = await self._setup(mock_coordinator, mock_hass, mock_entry)
+        assert added_entities == []
 
 
 class TestGetDeviceClassForName:

--- a/tests/unit/test_diagnostics.py
+++ b/tests/unit/test_diagnostics.py
@@ -203,4 +203,5 @@ class TestAsyncGetConfigEntryDiagnostics:
             "doors": {},
             "areas": {},
             "outputs": {},
+            "time_periods": {},
         }


### PR DESCRIPTION
## Summary

Exposes each configured Inception **Time Period** (e.g. "Business Hours", "Weekend") as a `binary_sensor` that reports whether the period is currently **active**. One sensor is created per configured time period, live-updated over the existing `/monitor-updates` long-poll.

## What changed

- **New schema** `pyinception/schemas/time_period.py` — `TimePeriodPublicState` (`ACTIVE` / `INACTIVE`), `TimePeriodSummaryEntry`, `TimePeriodSummary`, mirroring the Output schema.
- **API client** (`pyinception/api.py`)
  - `get_controls` learns the `time-period` control type.
  - `get_data` fetches time periods via a guarded `_get_time_periods()` helper.
  - A `TimePeriodState` sub-request is bundled into the shared long-poll **only when the controller actually returned time periods**.
- **Data** (`pyinception/data.py`) — `InceptionApiData` gains a `time_periods` field defaulting to an empty summary.
- **Binary sensor** (`binary_sensor.py`) — `InceptionTimePeriodBinarySensor`, one per time period, grouped as its own device under the controller panel (`via_device`). Icon `mdi:calendar-clock`; the sensor is the device's primary feature so HA labels it with the time period name.
- **Diagnostics** — the redacted coordinator dump now includes `time_periods`.
- **Tests** — schema parsing, `is_on` state, device grouping, empty-controller case, defensive fetch (success / 404-degrades / auth re-raises), and monitor bundling. Existing mocks updated for the new field/sub-request.

## API contract note (please verify against a real controller)

Time Periods are **not** part of the checked-in Postman collection (v16) or the `docs/inception-api/` sample surface, and the live `ApiDoc`/`ApiModelDoc` were unreachable from CI. This PR therefore follows the repo's own documented **universal control convention** (`entities.md`: "Every entity type exposes the same four shapes of endpoint under `api/v1/control/[type]`") with kebab-case paths (`lift-floor`, `storage-unit` → `time-period`):

- List + state: `GET /control/time-period/summary` → `{"TimePeriods": {id: {EntityInfo, CurrentState}}}`
- Live updates: `MonitorEntityStates` with `stateType: "TimePeriodState"`
- Active bit assumed `0x001` (mirrors Output `ON`)

If the real endpoint path, `stateType`, or the "active" bit value differ, they're isolated to `time_period.py` + the two `path_map`/`stateType` strings in `api.py` and easy to correct.

**Safety:** the fetch and the monitor sub-request are fully defensive — a controller that doesn't expose time periods degrades to an empty summary and sends **no** `TimePeriodState` sub-request, so the existing Area / Door / Input / Output entities are never affected.

## Testing

- `scripts/lint` — clean
- `scripts/tests` — 223 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018fRt6nY8ULKYAEuUzqP7Z4

---
_Generated by [Claude Code](https://claude.ai/code/session_018fRt6nY8ULKYAEuUzqP7Z4)_